### PR TITLE
extend sqd-archive metrics

### DIFF
--- a/crates/archive/src/chain_builder.rs
+++ b/crates/archive/src/chain_builder.rs
@@ -15,6 +15,8 @@ pub trait AnyChainBuilder: Send + Sync {
 
     fn last_block_number(&self) -> BlockNumber;
 
+    fn last_block_timestamp(&self) -> Option<i64>;
+
     fn last_block_hash(&self) -> &str;
 
     fn last_parent_block_number(&self) -> BlockNumber;
@@ -26,6 +28,7 @@ pub trait AnyChainBuilder: Send + Sync {
 pub struct ChainBuilder<B> {
     chunk_builder: B,
     last_block_number: BlockNumber,
+    last_block_timestamp: Option<i64>,
     last_block_hash: String,
     last_parent_block_hash: String,
     last_parent_block_number: BlockNumber,
@@ -35,6 +38,7 @@ pub struct ChainBuilder<B> {
 impl<B: Default> ChainBuilder<B> {
     pub fn new(
         base_block_number: BlockNumber,
+        base_block_timestamp: Option<i64>,
         base_block_hash: String,
         base_parent_block_number: BlockNumber,
         base_parent_block_hash: String,
@@ -42,6 +46,7 @@ impl<B: Default> ChainBuilder<B> {
         Self {
             chunk_builder: B::default(),
             last_block_number: base_block_number,
+            last_block_timestamp: base_block_timestamp,
             last_block_hash: base_block_hash,
             last_parent_block_number: base_parent_block_number,
             last_parent_block_hash: base_parent_block_hash,
@@ -52,7 +57,7 @@ impl<B: Default> ChainBuilder<B> {
 
 impl<B: Default> Default for ChainBuilder<B> {
     fn default() -> Self {
-        Self::new(0, String::new(), 0, String::new())
+        Self::new(0, None, String::new(), 0, String::new())
     }
 }
 
@@ -72,6 +77,7 @@ where
         }
         self.chunk_builder.push(&block)?;
         self.last_block_number = block.number();
+        self.last_block_timestamp = block.timestamp();
         self.last_block_hash.clear();
         self.last_block_hash.insert_str(0, block.hash());
         self.last_parent_block_number = block.parent_number();
@@ -93,6 +99,11 @@ where
     #[inline]
     fn last_block_number(&self) -> BlockNumber {
         self.last_block_number
+    }
+
+    #[inline]
+    fn last_block_timestamp(&self) -> Option<i64> {
+        self.last_block_timestamp
     }
 
     #[inline]
@@ -131,6 +142,11 @@ impl AnyChainBuilder for ChainBuilderBox {
     #[inline]
     fn last_block_number(&self) -> BlockNumber {
         self.as_ref().last_block_number()
+    }
+
+    #[inline]
+    fn last_block_timestamp(&self) -> Option<i64> {
+        self.as_ref().last_block_timestamp()
     }
 
     #[inline]

--- a/crates/archive/src/metrics.rs
+++ b/crates/archive/src/metrics.rs
@@ -1,13 +1,21 @@
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::gauge::Gauge;
+use crate::sink::Sink;
+use crate::writer::Writer;
+use prometheus_client::metrics::counter::{ConstCounter, Counter};
+use prometheus_client::metrics::gauge::{ConstGauge, Gauge};
 use prometheus_client::registry::Registry;
+use prometheus_client::collector::Collector;
+use prometheus_client::encoding::{DescriptorEncoder, EncodeMetric};
 use std::sync::atomic::AtomicU64;
 use std::sync::LazyLock;
+use std::fmt::{Formatter, Debug};
+use std::time::{Duration, UNIX_EPOCH};
 
 
 pub static PROGRESS: LazyLock<Gauge<f64, AtomicU64>> = LazyLock::new(Gauge::default);
-pub static LAST_BLOCK: LazyLock<Counter> = LazyLock::new(Counter::default);
-pub static LAST_SAVED_BLOCK: LazyLock<Counter> = LazyLock::new(Counter::default);
+pub static PROCESSING_TIME: LazyLock<Gauge<f64, AtomicU64>> = LazyLock::new(Gauge::default);
+pub static LAST_BLOCK: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
+pub static LAST_BLOCK_TIMESTAMP: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
+pub static LAST_SAVED_BLOCK: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
 
 
 pub fn register_metrics(registry: &mut Registry) {
@@ -17,13 +25,23 @@ pub fn register_metrics(registry: &mut Registry) {
         PROGRESS.clone()
     );
     registry.register(
-        "sqd_last_block",
-        "Last ingested block",
+        "sqd_blocks_processing_time",
+        "Time difference between now and block timestamp (in seconds)",
+        PROCESSING_TIME.clone()
+    );
+    registry.register(
+        "sqd_latest_processed_block_number",
+        "Latest processed block number",
         LAST_BLOCK.clone()
     );
     registry.register(
-        "sqd_last_saved_block",
-        "Last saved block",
+        "sqd_latest_processed_block_timestamp",
+        "Latest processed block timestamp",
+        LAST_BLOCK_TIMESTAMP.clone()
+    );
+    registry.register(
+        "sqd_latest_saved_block_number",
+        "Latest saved block number",
         LAST_SAVED_BLOCK.clone()
     );
 }

--- a/crates/archive/src/metrics.rs
+++ b/crates/archive/src/metrics.rs
@@ -13,9 +13,11 @@ use std::time::{Duration, UNIX_EPOCH};
 
 pub static PROGRESS: LazyLock<Gauge<f64, AtomicU64>> = LazyLock::new(Gauge::default);
 pub static PROCESSING_TIME: LazyLock<Gauge<f64, AtomicU64>> = LazyLock::new(Gauge::default);
-pub static LAST_BLOCK: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
-pub static LAST_BLOCK_TIMESTAMP: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
-pub static LAST_SAVED_BLOCK: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
+pub static LATEST_BLOCK_TIMESTAMP: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
+pub static LATEST_BLOCK: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
+pub static LATEST_SAVED_BLOCK: LazyLock<Gauge<u64, AtomicU64>> = LazyLock::new(Gauge::default);
+pub static LAST_BLOCK: LazyLock<Counter> = LazyLock::new(Counter::default);
+pub static LAST_SAVED_BLOCK: LazyLock<Counter> = LazyLock::new(Counter::default);
 
 
 pub fn register_metrics(registry: &mut Registry) {
@@ -32,16 +34,28 @@ pub fn register_metrics(registry: &mut Registry) {
     registry.register(
         "sqd_latest_processed_block_number",
         "Latest processed block number",
-        LAST_BLOCK.clone()
+        LATEST_BLOCK.clone()
     );
     registry.register(
         "sqd_latest_processed_block_timestamp",
         "Latest processed block timestamp",
-        LAST_BLOCK_TIMESTAMP.clone()
+        LATEST_BLOCK_TIMESTAMP.clone()
     );
     registry.register(
         "sqd_latest_saved_block_number",
         "Latest saved block number",
+        LATEST_SAVED_BLOCK.clone()
+    );
+
+    // kept for compatibility with the old metrics
+    registry.register(
+        "sqd_last_block",
+        "Last ingested block",
+        LAST_BLOCK.clone()
+    );
+    registry.register(
+        "sqd_last_saved_block",
+        "Last saved block",
         LAST_SAVED_BLOCK.clone()
     );
 }

--- a/crates/archive/src/processor.rs
+++ b/crates/archive/src/processor.rs
@@ -49,6 +49,10 @@ impl LineProcessor {
         self.state.builder.last_block_number()
     }
 
+    pub fn last_block_timestamp(&self) -> Option<i64> {
+        self.state.builder.last_block_timestamp()
+    }
+
     pub fn last_block_hash(&self) -> &str {
         self.state.builder.last_block_hash()
     }

--- a/crates/archive/src/sink.rs
+++ b/crates/archive/src/sink.rs
@@ -126,8 +126,9 @@ impl Sink {
 
                 let block_timestamp = self.processor.last_block_timestamp()
                     .map(|v| u64::try_from(v).unwrap()).unwrap_or(0);
-                metrics::LAST_BLOCK_TIMESTAMP.set(block_timestamp);
-                metrics::LAST_BLOCK.set(self.processor.last_block());
+                metrics::LATEST_BLOCK_TIMESTAMP.set(block_timestamp);
+                metrics::LATEST_BLOCK.set(self.processor.last_block());
+                metrics::LAST_BLOCK.inner().set(self.processor.last_block());
             }
         }
 

--- a/crates/archive/src/writer.rs
+++ b/crates/archive/src/writer.rs
@@ -62,7 +62,8 @@ impl Writer {
             let dest = format!("{}/blocks.parquet", chunk_path);
             self.fs.move_local(&blocks, &dest).await?;
 
-            metrics::LAST_SAVED_BLOCK.set(last_block);
+            metrics::LATEST_SAVED_BLOCK.set(last_block);
+            metrics::LAST_SAVED_BLOCK.inner().set(last_block);
         }
         Ok(())
     }

--- a/crates/archive/src/writer.rs
+++ b/crates/archive/src/writer.rs
@@ -62,7 +62,7 @@ impl Writer {
             let dest = format!("{}/blocks.parquet", chunk_path);
             self.fs.move_local(&blocks, &dest).await?;
 
-            metrics::LAST_SAVED_BLOCK.inner().set(last_block);
+            metrics::LAST_SAVED_BLOCK.set(last_block);
         }
         Ok(())
     }


### PR DESCRIPTION
@DamianFigiel here i've implemented requested metrics and renamed `sqd_last_saved_block` to `sqd_latest_saved_block_number` so it would match the common naming pattern