### PR TITLE
Support /finalized-stream in hotblocks DB

### DIFF
--- a/crates/hotblocks/src/dataset_controller/dataset_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/dataset_controller.rs
@@ -135,6 +135,18 @@ impl DatasetController {
             recv.changed().await.unwrap()
         }
     }
+
+    pub async fn wait_for_finalized_block(&self, block_number: BlockNumber) -> BlockNumber {
+        let mut recv = self.finalized_head_receiver.clone();
+        loop {
+            if let Some(block) = recv.borrow_and_update().as_ref() {
+                if block.number >= block_number {
+                    return block.number
+                }
+            }
+            recv.changed().await.unwrap()
+        }
+    }
 }
 
 

--- a/crates/hotblocks/src/query/response.rs
+++ b/crates/hotblocks/src/query/response.rs
@@ -24,6 +24,7 @@ impl QueryResponse {
         db: DBRef,
         dataset_id: DatasetId,
         query: Query,
+        only_finalized: bool,
     ) -> anyhow::Result<Self>
     {
         let Some(slot) = executor.get_slot() else {
@@ -33,7 +34,7 @@ impl QueryResponse {
         let start = Instant::now();
 
         let mut runner = slot.run(move |slot| -> anyhow::Result<_> {
-            let mut runner = RunningQuery::new(db, dataset_id, &query).map(Box::new)?;
+            let mut runner = RunningQuery::new(db, dataset_id, &query, only_finalized).map(Box::new)?;
             next_run(&mut runner, slot)?;
             Ok(runner)
         }).await?;


### PR DESCRIPTION
If finalized head is not available in the snapshot, throws HTTP 500. Otherwise, streams data capped to the finalized head