### PR TITLE
extend hotblocks metrics with client information

### DIFF
--- a/crates/hotblocks/src/api.rs
+++ b/crates/hotblocks/src/api.rs
@@ -81,10 +81,16 @@ pub async fn middleware(mut req: Request, next: axum::middleware::Next) -> impl 
     let version = req.version();
     let start = Instant::now();
 
+    let app = req
+        .extensions()
+        .get::<Arc<App>>()
+        .expect("App extension should be set");
+
     let client_id = req
         .headers()
-        .get("x-client-id")
+        .get("x-sqd-client-id")
         .and_then(|v| v.to_str().ok())
+        .filter(|v| app.known_clients.contains(*v))
         .unwrap_or(DEFAULT_CLIENT_ID)
         .to_string();
 

--- a/crates/hotblocks/src/api.rs
+++ b/crates/hotblocks/src/api.rs
@@ -5,7 +5,7 @@ use crate::errors::{
     UnknownDataset,
 };
 use crate::query::QueryResponse;
-use crate::types::RetentionStrategy;
+use crate::types::{ClientId, RetentionStrategy};
 use anyhow::bail;
 use async_stream::try_stream;
 use axum::body::{Body, Bytes};
@@ -24,6 +24,8 @@ use std::sync::Arc;
 use std::time::Instant;
 use tower_http::request_id::{MakeRequestUuid, RequestId, SetRequestIdLayer};
 use tracing::{Instrument, error};
+
+const DEFAULT_CLIENT_ID: &str = "unknown";
 
 macro_rules! json_ok {
     ($json:expr) => {
@@ -73,11 +75,21 @@ pub fn build_api(app: App) -> Router {
         .layer(Extension(Arc::new(app)))
 }
 
-pub async fn middleware(req: Request, next: axum::middleware::Next) -> impl IntoResponse {
+pub async fn middleware(mut req: Request, next: axum::middleware::Next) -> impl IntoResponse {
     let method = req.method().to_string();
     let path = req.uri().path().to_string();
     let version = req.version();
     let start = Instant::now();
+
+    let client_id = req
+        .headers()
+        .get("x-client-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(DEFAULT_CLIENT_ID)
+        .to_string();
+
+    req.extensions_mut().insert(ClientId::new(client_id));
+
     let request_id = req
         .extensions()
         .get::<RequestId>()
@@ -130,6 +142,13 @@ impl ResponseWithMetadata {
         }
     }
 
+    pub fn with_client_id(mut self, client_id: &ClientId) -> Self {
+        self.labels
+            .0
+            .push(("client_id", client_id.as_str().to_owned()));
+        self
+    }
+
     pub fn with_dataset_id(mut self, id: DatasetId) -> Self {
         self.labels.0.push(("dataset_name", id.as_str().to_owned()));
         self
@@ -159,11 +178,13 @@ impl IntoResponse for ResponseWithMetadata {
 
 async fn stream(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
     Json(query): Json<Query>,
 ) -> impl IntoResponse {
-    let response = stream_internal(app, dataset_id, query, false).await;
+    let response = stream_internal(app, dataset_id, query, false, client_id.clone()).await;
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id)
         .with_endpoint("/stream")
         .with_response(|| response)
@@ -171,11 +192,13 @@ async fn stream(
 
 async fn finalized_stream(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
     Json(query): Json<Query>,
 ) -> impl IntoResponse {
-    let response = stream_internal(app, dataset_id, query, true).await;
+    let response = stream_internal(app, dataset_id, query, true, client_id.clone()).await;
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id)
         .with_endpoint("/finalized_stream")
         .with_response(|| response)
@@ -186,6 +209,7 @@ async fn stream_internal(
     dataset_id: DatasetId,
     query: Query,
     finalized: bool,
+    client_id: ClientId,
 ) -> Response {
     let dataset = get_dataset!(app, dataset_id);
 
@@ -194,9 +218,11 @@ async fn stream_internal(
     }
 
     let query_result = if finalized {
-        app.query_service.query_finalized(&dataset, query).await
+        app.query_service
+            .query_finalized(&dataset, query, client_id)
+            .await
     } else {
-        app.query_service.query(&dataset, query).await
+        app.query_service.query(&dataset, query, client_id).await
     };
 
     match query_result {
@@ -304,9 +330,11 @@ struct BaseBlockConflict<'a> {
 
 async fn get_finalized_head(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
 ) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id.clone())
         .with_endpoint("/finalized_head")
         .with_response(|| {
@@ -318,9 +346,11 @@ async fn get_finalized_head(
 
 async fn get_head(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
 ) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id.clone())
         .with_endpoint("/head")
         .with_response(|| {
@@ -332,9 +362,11 @@ async fn get_head(
 
 async fn get_retention(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
 ) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id.clone())
         .with_endpoint("/retention")
         .with_response(|| {
@@ -346,10 +378,12 @@ async fn get_retention(
 
 async fn set_retention(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
     Json(strategy): Json<RetentionStrategy>,
 ) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id.clone())
         .with_endpoint("/retention")
         .with_response(|| {
@@ -369,6 +403,7 @@ async fn set_retention(
 
 async fn get_status(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
 ) -> impl IntoResponse {
     let read_status = |ctl: Arc<DatasetController>| -> anyhow::Result<_> {
@@ -404,6 +439,7 @@ async fn get_status(
     };
 
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id.clone())
         .with_endpoint("/status")
         .with_response(|| {
@@ -417,9 +453,11 @@ async fn get_status(
 
 async fn get_metadata(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path(dataset_id): Path<DatasetId>,
 ) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_dataset_id(dataset_id.clone())
         .with_endpoint("/metadata")
         .with_response(|| {
@@ -441,19 +479,27 @@ async fn get_metadata(
         })
 }
 
-async fn get_metrics(Extension(app): Extension<AppRef>) -> impl IntoResponse {
+async fn get_metrics(
+    Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
+) -> impl IntoResponse {
     let mut metrics = String::new();
 
     prometheus_client::encoding::text::encode(&mut metrics, &app.metrics_registry)
         .expect("String IO is infallible");
 
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_endpoint("/metrics")
         .with_response(|| metrics.into_response())
 }
 
-async fn get_rocks_stats(Extension(app): Extension<AppRef>) -> impl IntoResponse {
+async fn get_rocks_stats(
+    Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
+) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_endpoint("/rocks_stats")
         .with_response(|| {
             if let Some(stats) = app.db.get_statistics() {
@@ -469,9 +515,11 @@ async fn get_rocks_stats(Extension(app): Extension<AppRef>) -> impl IntoResponse
 
 async fn get_rocks_prop(
     Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
     Path((cf, name)): Path<(String, String)>,
 ) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_endpoint("/rocks_prop")
         .with_response(|| match app.db.get_property(&cf, &name) {
             Ok(Some(s)) => s.into_response(),
@@ -480,8 +528,9 @@ async fn get_rocks_prop(
         })
 }
 
-async fn handle_404(uri: Uri) -> impl IntoResponse {
+async fn handle_404(Extension(client_id): Extension<ClientId>, uri: Uri) -> impl IntoResponse {
     ResponseWithMetadata::new()
+        .with_client_id(&client_id)
         .with_endpoint("404_fallback")
         .with_response(|| text!(StatusCode::NOT_FOUND, "Not found: {}", uri.path()))
 }

--- a/crates/hotblocks/src/cli.rs
+++ b/crates/hotblocks/src/cli.rs
@@ -6,7 +6,7 @@ use crate::types::DBRef;
 use anyhow::Context;
 use clap::Parser;
 use sqd_storage::db::{DatabaseSettings, DatasetId};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::Arc;
 
 #[derive(Parser, Debug)]
@@ -46,6 +46,11 @@ pub struct CLI {
 
     #[arg(long)]
     pub rocksdb_disable_direct_io: bool,
+
+    /// Known client IDs for metrics labeling. Client IDs not in this list
+    /// will be reported as "other" to prevent metrics cardinality abuse.
+    #[arg(long = "known-client", value_name = "ID")]
+    pub known_clients: Vec<String>,
 }
 
 pub struct App {
@@ -54,6 +59,7 @@ pub struct App {
     pub query_service: QueryServiceRef,
     pub api_controlled_datasets: BTreeSet<DatasetId>,
     pub metrics_registry: prometheus_client::registry::Registry,
+    pub known_clients: HashSet<String>,
 }
 
 impl CLI {
@@ -101,12 +107,15 @@ impl CLI {
             Arc::new(service)
         };
 
+        let known_clients: HashSet<String> = self.known_clients.iter().cloned().collect();
+
         Ok(App {
             db,
             data_service,
             query_service,
             api_controlled_datasets,
             metrics_registry,
+            known_clients,
         })
     }
 }

--- a/crates/hotblocks/src/cli.rs
+++ b/crates/hotblocks/src/cli.rs
@@ -48,7 +48,7 @@ pub struct CLI {
     pub rocksdb_disable_direct_io: bool,
 
     /// Known client IDs for metrics labeling. Client IDs not in this list
-    /// will be reported as "other" to prevent metrics cardinality abuse.
+    /// will be reported as "unknown" to prevent metrics cardinality abuse.
     #[arg(long = "known-client", value_name = "ID")]
     pub known_clients: Vec<String>,
 }

--- a/crates/hotblocks/src/metrics.rs
+++ b/crates/hotblocks/src/metrics.rs
@@ -68,8 +68,9 @@ pub static STREAM_BLOCKS: LazyLock<Family<Labels, Histogram>> = LazyLock::new(||
 });
 pub static STREAM_CHUNKS: LazyLock<Family<Labels, Histogram>> =
     LazyLock::new(|| Family::new_with_constructor(|| Histogram::new(buckets(1., 20))));
-pub static STREAM_BYTES_PER_SECOND: LazyLock<Histogram> =
-    LazyLock::new(|| Histogram::new(exponential_buckets(100., 3.0, 20)));
+pub static STREAM_BYTES_PER_SECOND: LazyLock<Family<Labels, Histogram>> = LazyLock::new(|| {
+    Family::new_with_constructor(|| Histogram::new(exponential_buckets(100., 3.0, 20)))
+});
 pub static STREAM_BLOCKS_PER_SECOND: LazyLock<Family<Labels, Histogram>> = LazyLock::new(|| {
     Family::new_with_constructor(|| Histogram::new(exponential_buckets(1., 3.0, 20)))
 });

--- a/crates/hotblocks/src/query/response.rs
+++ b/crates/hotblocks/src/query/response.rs
@@ -5,6 +5,7 @@ use crate::metrics::{
     STREAM_BLOCKS, STREAM_BLOCKS_PER_SECOND, STREAM_BYTES, STREAM_BYTES_PER_SECOND, STREAM_CHUNKS,
     STREAM_DURATIONS,
 };
+use crate::types::ClientId;
 use crate::types::DBRef;
 use anyhow::bail;
 use bytes::Bytes;
@@ -21,6 +22,7 @@ pub struct QueryResponse {
     runner: Option<Box<RunningQuery>>,
     finalized_head: Option<BlockRef>,
     dataset_id: DatasetId,
+    client_id: ClientId,
     stats: QueryStreamStats,
     time_limit: Duration,
 }
@@ -52,8 +54,11 @@ impl QueryStreamStats {
             .saturating_add(running_stats.blocks_returned);
     }
 
-    fn report_metrics(&self, dataset_id: &DatasetId) {
-        let labels = vec![("dataset_name", dataset_id.as_str().to_owned())];
+    fn report_metrics(&self, dataset_id: &DatasetId, client_id: &ClientId) {
+        let labels = vec![
+            ("client_id", client_id.as_str().to_owned()),
+            ("dataset_name", dataset_id.as_str().to_owned()),
+        ];
 
         let duration = self.start_time.elapsed().as_secs_f64();
         let bytes = self.response_bytes as f64;
@@ -65,7 +70,9 @@ impl QueryStreamStats {
         STREAM_BLOCKS.get_or_create(&labels).observe(blocks);
         STREAM_CHUNKS.get_or_create(&labels).observe(chunks);
         if duration > 0.0 {
-            STREAM_BYTES_PER_SECOND.observe(bytes / duration);
+            STREAM_BYTES_PER_SECOND
+                .get_or_create(&labels)
+                .observe(bytes / duration);
             STREAM_BLOCKS_PER_SECOND
                 .get_or_create(&labels)
                 .observe(blocks / duration);
@@ -81,6 +88,7 @@ impl QueryResponse {
         query: Query,
         only_finalized: bool,
         time_limit: Option<Duration>,
+        client_id: ClientId,
     ) -> anyhow::Result<Self> {
         let Some(slot) = executor.get_slot() else {
             bail!(Busy)
@@ -103,6 +111,7 @@ impl QueryResponse {
             runner: Some(runner),
             stats,
             dataset_id,
+            client_id,
             time_limit,
         };
 
@@ -165,8 +174,9 @@ impl QueryResponse {
     }
 
     fn finish_with_runner(&mut self, runner: Box<RunningQuery>) -> Option<Bytes> {
-        runner.stats().report_metrics(&self.dataset_id);
-        self.stats.add_running_stats(runner.stats());
+        let stats = runner.stats();
+        stats.report_metrics(&self.dataset_id, &self.client_id);
+        self.stats.add_running_stats(stats);
         let bytes = runner.finish();
         self.stats.response_bytes = self.stats.response_bytes.saturating_add(bytes.len() as u64);
         Some(bytes)
@@ -182,7 +192,7 @@ impl QueryResponse {
 
 impl Drop for QueryResponse {
     fn drop(&mut self) {
-        self.stats.report_metrics(&self.dataset_id)
+        self.stats.report_metrics(&self.dataset_id, &self.client_id)
     }
 }
 

--- a/crates/hotblocks/src/query/running.rs
+++ b/crates/hotblocks/src/query/running.rs
@@ -2,7 +2,7 @@ use crate::errors::{BlockItemIsNotAvailable, QueryKindMismatch};
 use crate::errors::{BlockRangeMissing, QueryIsAboveTheHead};
 use crate::metrics::{QUERIED_BLOCKS, QUERIED_CHUNKS};
 use crate::query::static_snapshot::{StaticChunkIterator, StaticChunkReader, StaticSnapshot};
-use crate::types::{DBRef, DatasetKind};
+use crate::types::{ClientId, DBRef, DatasetKind};
 use anyhow::{anyhow, bail, ensure};
 use bytes::{BufMut, Bytes, BytesMut};
 use flate2::Compression;
@@ -22,7 +22,6 @@ pub struct RunningQueryStats {
     pub blocks_read: u64,
     pub chunks_returned: u64,
     pub blocks_returned: u64
-
 }
 
 impl RunningQueryStats {
@@ -35,8 +34,11 @@ impl RunningQueryStats {
         }
     }
 
-    pub fn report_metrics(&self, dataset_id: &DatasetId) {
-        let labels = vec![("dataset_id", dataset_id.as_str().to_owned())];
+    pub fn report_metrics(&self, dataset_id: &DatasetId, client_id: &ClientId) {
+        let labels = vec![
+            ("client_id", client_id.as_str().to_owned()),
+            ("dataset_id", dataset_id.as_str().to_owned()),
+        ];
 
         QUERIED_BLOCKS
             .get_or_create(&labels)

--- a/crates/hotblocks/src/query/service.rs
+++ b/crates/hotblocks/src/query/service.rs
@@ -2,7 +2,7 @@ use super::executor::QueryExecutor;
 use super::response::QueryResponse;
 use crate::dataset_controller::DatasetController;
 use crate::errors::{Busy, QueryIsAboveTheHead, QueryKindMismatch};
-use crate::types::{DBRef, DatasetKind};
+use crate::types::{ClientId, DBRef, DatasetKind};
 use crate::query::QueryExecutorCollector;
 use anyhow::{bail, ensure};
 use sqd_query::Query;
@@ -82,16 +82,18 @@ impl QueryService {
         &self,
         dataset: &DatasetController,
         query: Query,
+        client_id: ClientId,
     ) -> anyhow::Result<QueryResponse> {
-        self.query_internal(dataset, query, false).await
+        self.query_internal(dataset, query, false, client_id).await
     }
 
     pub async fn query_finalized(
         &self,
         dataset: &DatasetController,
         query: Query,
+        client_id: ClientId,
     ) -> anyhow::Result<QueryResponse> {
-        self.query_internal(dataset, query, true).await
+        self.query_internal(dataset, query, true, client_id).await
     }
 
     async fn query_internal(
@@ -99,6 +101,7 @@ impl QueryService {
         dataset: &DatasetController,
         query: Query,
         finalized: bool,
+        client_id: ClientId,
     ) -> anyhow::Result<QueryResponse> {
         ensure!(
             dataset.dataset_kind() == DatasetKind::from_query(&query),
@@ -154,7 +157,8 @@ impl QueryService {
             dataset.dataset_id(),
             query,
             finalized,
-            None
+            None,
+            client_id,
         ).await
     }
 

--- a/crates/hotblocks/src/types.rs
+++ b/crates/hotblocks/src/types.rs
@@ -70,3 +70,17 @@ pub enum RetentionStrategy {
     Head(u64),
     None
 }
+
+
+#[derive(Clone, Debug)]
+pub struct ClientId(String);
+
+impl ClientId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}


### PR DESCRIPTION
this pr extends existing metrics with information about client. in order to use it client should add `x-client-id` header