### PR TITLE
Fix query planner bug leading to HTTP 500 NET-536

### DIFF
--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction/query.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction/query.json
@@ -1,0 +1,24 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881390,
+  "logs": [
+    { "transaction": true }
+  ],
+  "fields": {
+    "log": {
+      "logIndex": true,
+      "transactionIndex": true,
+      "address": true
+    },
+    "transaction": {
+      "transactionIndex": true,
+      "from": true,
+      "sighash": true
+    },
+    "block": {
+      "number": true,
+      "hash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction/result.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f6d416a6e39b0ef749ddf3cc51735cfb5c7369a301dfe09ee61b619366e104f
+size 64155

--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_logs/query.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_logs/query.json
@@ -1,0 +1,19 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881390,
+  "logs": [
+    { "transactionLogs": true }
+  ],
+  "fields": {
+    "log": {
+      "logIndex": true,
+      "transactionIndex": true,
+      "address": true
+    },
+    "block": {
+      "number": true,
+      "hash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_logs/result.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_logs/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52480765f4f0036f661515636ffe0eff6b2d256a435d92d7d0a952f75a135f02
+size 51531

--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_state_diffs/query.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_state_diffs/query.json
@@ -1,0 +1,24 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881390,
+  "logs": [
+    { "transactionStateDiffs": true }
+  ],
+  "fields": {
+    "log": {
+      "logIndex": true,
+      "transactionIndex": true,
+      "address": true
+    },
+    "stateDiff": {
+      "transactionIndex": true,
+      "address": true,
+      "key": true
+    },
+    "block": {
+      "number": true,
+      "hash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_state_diffs/result.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_state_diffs/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b426457e4bbad63fbdd85134d09f284c68764b6a20c8acce4d7968e378dcb503
+size 172503

--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_traces/query.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_traces/query.json
@@ -1,0 +1,24 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881390,
+  "logs": [
+    { "transactionTraces": true }
+  ],
+  "fields": {
+    "log": {
+      "logIndex": true,
+      "transactionIndex": true,
+      "address": true
+    },
+    "trace": {
+      "transactionIndex": true,
+      "traceAddress": true,
+      "type": true
+    },
+    "block": {
+      "number": true,
+      "hash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_traces/result.json
+++ b/crates/query/fixtures/ethereum/queries/logs_no_predicate_with_transaction_traces/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f01c7555b39948032669765da41d3ae94c388177f10c36afa9508e58a437d01f
+size 142025

--- a/crates/query/fixtures/ethereum/queries/state_diffs_no_predicate_with_transaction/query.json
+++ b/crates/query/fixtures/ethereum/queries/state_diffs_no_predicate_with_transaction/query.json
@@ -1,0 +1,24 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881390,
+  "stateDiffs": [
+    { "transaction": true }
+  ],
+  "fields": {
+    "stateDiff": {
+      "transactionIndex": true,
+      "address": true,
+      "key": true
+    },
+    "transaction": {
+      "transactionIndex": true,
+      "from": true,
+      "sighash": true
+    },
+    "block": {
+      "number": true,
+      "hash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/state_diffs_no_predicate_with_transaction/result.json
+++ b/crates/query/fixtures/ethereum/queries/state_diffs_no_predicate_with_transaction/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebb00d495cbdbc7cd3ec2ca10a601cadc1a033a6a026d61bb195c615237c8c7b
+size 161745

--- a/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction/query.json
+++ b/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction/query.json
@@ -1,0 +1,24 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881390,
+  "traces": [
+    { "transaction": true }
+  ],
+  "fields": {
+    "trace": {
+      "transactionIndex": true,
+      "traceAddress": true,
+      "type": true
+    },
+    "transaction": {
+      "transactionIndex": true,
+      "from": true,
+      "sighash": true
+    },
+    "block": {
+      "number": true,
+      "hash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction/result.json
+++ b/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a045614b7fe336cc7825c4253a7a33897c23d91194741828b617214e945900d2
+size 113578

--- a/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction_logs/query.json
+++ b/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction_logs/query.json
@@ -1,0 +1,24 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881390,
+  "traces": [
+    { "transactionLogs": true }
+  ],
+  "fields": {
+    "trace": {
+      "transactionIndex": true,
+      "traceAddress": true,
+      "type": true
+    },
+    "log": {
+      "logIndex": true,
+      "transactionIndex": true,
+      "address": true
+    },
+    "block": {
+      "number": true,
+      "hash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction_logs/result.json
+++ b/crates/query/fixtures/ethereum/queries/traces_no_predicate_with_transaction_logs/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c148063925122664cfa2a76e3e6ec20906f6fdaa2e714d569db73a74f2aa9ed
+size 147033

--- a/crates/query/src/plan/plan.rs
+++ b/crates/query/src/plan/plan.rs
@@ -726,7 +726,10 @@ impl PlanBuilder {
             .enumerate()
             .filter(|(idx, _)| is_full_rel[*idx])
         {
-            let table = rel.output_table();
+            // The new scan must read the relation's *input* table, since
+            // execute_scans feeds scan rows into relation_inputs[rel_idx],
+            // which eval_join etc. interpret as row indexes of input_table.
+            let table = rel.input_table();
             let scan = new_scans.entry(table).or_insert_with(|| Scan {
                 table,
                 predicate: None,

--- a/crates/query/src/plan/plan.rs
+++ b/crates/query/src/plan/plan.rs
@@ -739,7 +739,32 @@ impl PlanBuilder {
             scan.relations.push(idx);
         }
 
-        self.scans.extend(new_scans.into_values())
+        self.scans.extend(new_scans.into_values());
+
+        self.assert_scan_relation_invariant();
+    }
+
+    /// Verifies that every scan's relations have an `input_table` matching the
+    /// scan's table. This is the contract `execute_scans` relies on: rows read
+    /// from `scan.table` are pushed into `relation_inputs[rel_idx]` and later
+    /// interpreted by `rel.eval` as row indexes of `rel.input_table()`. A
+    /// mismatch produces silently wrong row selections that surface as
+    /// out-of-bounds reads on whichever column is read first.
+    fn assert_scan_relation_invariant(&self) {
+        for scan in self.scans.iter() {
+            for &rel_idx in scan.relations.iter() {
+                let rel = &self.relations[rel_idx];
+                assert_eq!(
+                    rel.input_table(),
+                    scan.table,
+                    "plan invariant violated: scan on {:?} owns relation {} \
+                     whose input_table is {:?}",
+                    scan.table,
+                    rel_idx,
+                    rel.input_table()
+                );
+            }
+        }
     }
 
     fn remove_relations(&mut self, remove_mask: &[bool]) {
@@ -882,5 +907,180 @@ impl<'a> ScanBuilder<'a> {
 
     fn scan_mut(&mut self) -> &mut Scan {
         &mut self.plan.scans[self.scan_idx]
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::col_gt_eq;
+    use std::sync::OnceLock;
+
+    /// Tables with a `transactions` parent and `logs` child, plus an explicit
+    /// `add_child("logs", ...)` registration on transactions. The logs side has
+    /// no children of its own — so a `logs -> transactions` join is *not* a
+    /// "full rel" (logs.primary_key != input_key, and logs.children is empty),
+    /// which is exactly the shape that triggered the production bug.
+    fn evm_like_tables() -> &'static TableSet {
+        static TABLES: OnceLock<TableSet> = OnceLock::new();
+        TABLES.get_or_init(|| {
+            let mut t = TableSet::new();
+            t.add_table("blocks", vec!["number"]);
+            t.add_table(
+                "transactions",
+                vec!["block_number", "transaction_index"],
+            )
+            .add_child("logs", vec!["block_number", "transaction_index"]);
+            t.add_table("logs", vec!["block_number", "log_index"]);
+            t
+        })
+    }
+
+    /// Tables where logs is a child of transactions AND transactions is a child
+    /// of logs with a matching key. With that, a `logs -> transactions` join
+    /// where input_key == logs.primary_key would be a "full rel". Used by the
+    /// full-rel-removal test.
+    fn full_rel_tables() -> &'static TableSet {
+        static TABLES: OnceLock<TableSet> = OnceLock::new();
+        TABLES.get_or_init(|| {
+            let mut t = TableSet::new();
+            t.add_table("blocks", vec!["number"]);
+            t.add_table("transactions", vec!["block_number", "transaction_index"]);
+            t.add_table("logs", vec!["block_number", "log_index"])
+                .add_child("transactions", vec!["block_number", "log_index"]);
+            t
+        })
+    }
+
+    /// Reproducer for the original bug. A predicate-less log selector with a
+    /// `transaction: true` join (modelled as `add_scan("logs").join("transactions", ...)`)
+    /// must end up attached to a logs-table scan after simplification — never
+    /// to the transactions-table scan. Pre-fix, simplify() keyed the new scan
+    /// by `rel.output_table()`, so the join was reattached to a transactions
+    /// scan and execute_scans fed transactions row indexes into a logs-input
+    /// slot.
+    #[test]
+    fn simplify_attaches_surviving_relations_to_input_table_scan() {
+        let mut builder = PlanBuilder::new(evm_like_tables());
+        builder
+            .add_scan("logs")
+            .join(
+                "transactions",
+                vec!["block_number", "transaction_index"],
+                vec!["block_number", "transaction_index"],
+            );
+
+        let plan = builder.build();
+
+        assert_eq!(plan.relations.len(), 1, "join relation must survive");
+        let rel = &plan.relations[0];
+        assert_eq!(rel.input_table(), "logs");
+        assert_eq!(rel.output_table(), "transactions");
+
+        let owning_scan = plan
+            .scans
+            .iter()
+            .find(|s| s.relations.contains(&0))
+            .expect("some scan must own the surviving relation");
+        assert_eq!(
+            owning_scan.table, "logs",
+            "relation with input_table=logs must be attached to a logs-scan, not a {}-scan",
+            owning_scan.table
+        );
+    }
+
+    /// When the relation IS a "full rel" (input fully populated implies output
+    /// fully populated), simplify() must drop it entirely and replace it with
+    /// a direct full scan on the output table. No relation should survive.
+    #[test]
+    fn simplify_drops_full_rel_and_replaces_with_direct_scan() {
+        let mut builder = PlanBuilder::new(full_rel_tables());
+        builder
+            .add_scan("logs")
+            .join(
+                "transactions",
+                vec!["block_number", "log_index"],
+                vec!["block_number", "log_index"],
+            );
+
+        let plan = builder.build();
+
+        assert!(
+            plan.relations.is_empty(),
+            "full rel must be removed during simplification, got {:?} relations",
+            plan.relations.len()
+        );
+        // Both outputs should still be populated by direct scans, with no relations.
+        for table in ["logs", "transactions"] {
+            assert!(
+                plan.scans.iter().any(|s| s.table == table && s.relations.is_empty()),
+                "expected a relation-less scan for {}; scans = {:?}",
+                table,
+                plan.scans.iter().map(|s| s.table).collect::<Vec<_>>()
+            );
+        }
+    }
+
+    /// Mixed plan: one predicate-less log scan and one predicated log scan that
+    /// joins to transactions. The predicate-less scan goes through the
+    /// "is_full" path, while the predicated scan must keep its join. The whole
+    /// plan must still satisfy the input-table invariant.
+    #[test]
+    fn simplify_preserves_invariant_with_mixed_predicated_and_unpredicated_scans() {
+        let mut builder = PlanBuilder::new(evm_like_tables());
+        // Predicate-less logs scan.
+        builder.add_scan("logs");
+        // Predicated logs scan with a join.
+        builder
+            .add_scan("logs")
+            .with_predicate(col_gt_eq("block_number", 0u64))
+            .join(
+                "transactions",
+                vec!["block_number", "transaction_index"],
+                vec!["block_number", "transaction_index"],
+            );
+
+        let plan = builder.build();
+
+        // The surviving join must still be attached to a logs scan that owns
+        // it; the surviving logs scan with a predicate is the natural owner.
+        let join_idx = plan
+            .relations
+            .iter()
+            .position(|r| r.input_table() == "logs" && r.output_table() == "transactions")
+            .expect("logs->transactions join must survive");
+        let owning_scan = plan
+            .scans
+            .iter()
+            .find(|s| s.relations.contains(&join_idx))
+            .expect("some scan must own the join");
+        assert_eq!(owning_scan.table, "logs");
+    }
+
+    /// Direct guard test: assemble a PlanBuilder whose scan owns a relation
+    /// with a mismatched input_table and confirm the invariant assertion fires.
+    /// This is the safety net that turns every future planning code path into
+    /// an implicit verifier of the input-table contract.
+    #[test]
+    #[should_panic(expected = "plan invariant violated")]
+    fn assert_scan_relation_invariant_panics_on_input_table_mismatch() {
+        let mut builder = PlanBuilder::new(evm_like_tables());
+        // Manually construct a malformed plan: a scan on `transactions` that
+        // owns a `logs -> transactions` join. This is the exact shape produced
+        // by the pre-fix simplify() and is what must be rejected.
+        builder.relations.push(Rel::Join {
+            input_table: "logs",
+            input_key: vec!["block_number", "transaction_index"],
+            output_table: "transactions",
+            output_key: vec!["block_number", "transaction_index"],
+        });
+        builder.scans.push(Scan {
+            table: "transactions",
+            predicate: None,
+            relations: vec![0],
+            output: None,
+        });
+        builder.assert_scan_relation_invariant();
     }
 }

--- a/crates/query/src/plan/rel.rs
+++ b/crates/query/src/plan/rel.rs
@@ -51,6 +51,16 @@ impl Rel {
         }
     }
 
+    pub fn input_table(&self) -> Name {
+        match self {
+            Rel::Join { input_table, .. } => input_table,
+            Rel::ForeignChildren { input_table, .. } => input_table,
+            Rel::ForeignParents { input_table, .. } => input_table,
+            Rel::Children { table, .. } => table,
+            Rel::Parents { table, .. } => table
+        }
+    }
+
     pub fn eval(
         &self,
         chunk: &dyn Chunk,


### PR DESCRIPTION
# Fix: query planner routed simplified relations to the wrong scan table

## What broke

Hotblocks returned `500 Internal Server Error` for queries like this: `{"logs": [{"transaction": true}], "fromBlock": N, "includeAllBlocks": true}`. The response was:

```
failed to read column 'block_number'
Caused by:
  0: failed to read values buffer
  1: range list is out of bounds: 26693 < 30966
```

Where `26693` is the row count of the chunk's `logs` table and `30966` is the row count of the same chunk's `transactions` table.

## Root cause

`PlanBuilder::simplify()` in `crates/query/src/plan/plan.rs` rewrites the plan when a query has a predicate-less selector (the no-filter shape selects the whole table; the simplification adds a direct full scan and drops anything redundant).

When the surviving relation isn't a "full rel" (its `input_key` doesn't match the input table's `primary_key`), the relation still needs to be evaluated against rows from its `input_table`. The current code keyed the new scan on `rel.output_table()` instead:

```rust
let table = rel.output_table();  // wrong
```

In `execute_scans` each scan reads rows from `scan.table` and pushes their row indexes into `relation_inputs[rel_idx]`. `eval_join` then interprets those indexes as positions in `rel.input_table()`. With the wrong key, `transactions` row indexes (0..30966) were fed into a slot that `eval_join` later applied as a `row_selection` to the `logs` table (0..26693 rows) → out-of-bounds in `pagination.rs`.

For EVM log selectors the trigger is structural: `logs.primary_key = [block_number, log_index]` but the join's `input_key = [block_number, transaction_index]`, so `is_full_rel(rel)` returns `false` and the relation always survives simplification.

## Fix

`Rel::input_table()` accessor added next to the existing `output_table()`. `simplify()` now keys the new scan on `rel.input_table()`.

To safeguard against other occurrences, `PlanBuilder::assert_scan_relation_invariant()` runs at the end of `simplify()` and checks that every scan owns only relations whose `input_table` matches the scan's own table — the contract `execute_scans` already assumes. Running this `assert!` in release is cheap — planning runs once per request, and the cost is a short vector walk.

## Tests

Added unit tests in `plan.rs`:

- `simplify_attaches_surviving_relations_to_input_table_scan` — the direct reproducer.
- `simplify_drops_full_rel_and_replaces_with_direct_scan` — covers the full-rel branch: relation is dropped and replaced with a direct scan.
- `simplify_preserves_invariant_with_mixed_predicated_and_unpredicated_scans` — predicated and predicate-less scans on the same table coexist; invariant still holds.
- `assert_scan_relation_invariant_panics_on_input_table_mismatch` — independently verifies the guard fires on a manually mismatched plan.