### PR TITLE
Extend evm trace api

### DIFF
--- a/crates/query/docs/evm-query-syntax.md
+++ b/crates/query/docs/evm-query-syntax.md
@@ -290,12 +290,17 @@ Item requests define filters for selecting blockchain data. Multiple requests of
       "type": ["call", "create"],
       "createFrom": ["0x..."],
       "createResultAddress": ["0x..."],
+      "createValueNonZero": true,
       "callFrom": ["0x..."],
       "callTo": ["0x..."],
       "callSighash": ["0x..."],
+      "callCallType": ["call", "delegatecall"],
+      "callValueNonZero": true,
       "suicideAddress": ["0x..."],
       "suicideRefundAddress": ["0x..."],
+      "suicideBalanceNonZero": true,
       "rewardAuthor": ["0x..."],
+      "rewardValueNonZero": true,
       "transaction": true,
       "transactionLogs": true,
       "subtraces": true,
@@ -312,12 +317,17 @@ Item requests define filters for selecting blockchain data. Multiple requests of
 | `type` | string[] | Match traces of these types: `"create"`, `"call"`, `"suicide"`, `"reward"` |
 | `createFrom` | string[] | Match create traces from any of these addresses |
 | `createResultAddress` | string[] | Match create traces that deployed contracts at these addresses |
+| `createValueNonZero` | boolean | When `true`, only match create traces where `createValue` is non-zero and non-null |
 | `callFrom` | string[] | Match call traces from any of these addresses |
 | `callTo` | string[] | Match call traces to any of these addresses |
 | `callSighash` | string[] | Match call traces with any of these function selectors |
+| `callCallType` | string[] | Match call traces with any of these call types: `"call"`, `"delegatecall"`, `"staticcall"`, `"callcode"` |
+| `callValueNonZero` | boolean | When `true`, only match call traces where `callValue` is non-zero and non-null |
 | `suicideAddress` | string[] | Match suicide traces for any of these contract addresses |
 | `suicideRefundAddress` | string[] | Match suicide traces refunding to any of these addresses |
+| `suicideBalanceNonZero` | boolean | When `true`, only match suicide traces where `suicideBalance` is non-zero and non-null |
 | `rewardAuthor` | string[] | Match reward traces to any of these authors |
+| `rewardValueNonZero` | boolean | When `true`, only match reward traces where `rewardValue` is non-zero and non-null |
 
 **Relation fields:**
 

--- a/crates/query/fixtures/ethereum/queries/trace_call_type/query.json
+++ b/crates/query/fixtures/ethereum/queries/trace_call_type/query.json
@@ -1,0 +1,25 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881870,
+  "fields": {
+    "trace": {
+      "callFrom": true,
+      "callType": true,
+      "transactionIndex": true,
+      "traceAddress": true,
+      "type": true
+    },
+    "block": {
+      "number": true,
+      "hash": true,
+      "parentHash": true
+    }
+  },
+  "traces": [
+    {
+      "callFrom": ["0x58df81babdf15276e761808e872a3838cbecbcf9"],
+      "callType": ["staticcall"]
+    }
+  ]
+}

--- a/crates/query/fixtures/ethereum/queries/trace_call_type/query.json
+++ b/crates/query/fixtures/ethereum/queries/trace_call_type/query.json
@@ -5,7 +5,7 @@
   "fields": {
     "trace": {
       "callFrom": true,
-      "callType": true,
+      "callCallType": true,
       "transactionIndex": true,
       "traceAddress": true,
       "type": true
@@ -19,7 +19,7 @@
   "traces": [
     {
       "callFrom": ["0x58df81babdf15276e761808e872a3838cbecbcf9"],
-      "callType": ["staticcall"]
+      "callCallType": ["staticcall"]
     }
   ]
 }

--- a/crates/query/fixtures/ethereum/queries/trace_call_type/result.json
+++ b/crates/query/fixtures/ethereum/queries/trace_call_type/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:542a37a1fca0ed0c472a50bc4a05fc99b2ec0b4464adea6fdb81e57b7c2b86b5
+size 578038

--- a/crates/query/fixtures/ethereum/queries/trace_call_type/result.json
+++ b/crates/query/fixtures/ethereum/queries/trace_call_type/result.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:542a37a1fca0ed0c472a50bc4a05fc99b2ec0b4464adea6fdb81e57b7c2b86b5
-size 578038
+oid sha256:567a5d16ab94687d3c86741acd7a996ade3abcdc95e8b9c5d9b13a58119a1e9d
+size 586330

--- a/crates/query/fixtures/ethereum/queries/trace_value_non_zero/query.json
+++ b/crates/query/fixtures/ethereum/queries/trace_value_non_zero/query.json
@@ -4,7 +4,7 @@
   "toBlock": 17881870,
   "fields": {
     "trace": {
-      "callType": true,
+      "callCallType": true,
       "callSighash": true,
       "callValue": true,
       "createResultAddress": true,
@@ -27,7 +27,7 @@
       "createValueNonZero": true
     },
     {
-      "callType": ["call"],
+      "callCallType": ["call"],
       "callSighash": ["0x3598d8ab"],
       "callValueNonZero": true
     },

--- a/crates/query/fixtures/ethereum/queries/trace_value_non_zero/query.json
+++ b/crates/query/fixtures/ethereum/queries/trace_value_non_zero/query.json
@@ -1,0 +1,38 @@
+{
+  "type": "evm",
+  "fromBlock": 17881390,
+  "toBlock": 17881870,
+  "fields": {
+    "trace": {
+      "callType": true,
+      "callSighash": true,
+      "callValue": true,
+      "createResultAddress": true,
+      "createValue": true,
+      "suicideRefundAddress": true,
+      "suicideBalance": true,
+      "rewardValue": true,
+      "transactionIndex": true,
+      "traceAddress": true,
+      "type": true
+    },
+    "block": {
+      "number": true,
+      "hash": true,
+      "parentHash": true
+    }
+  },
+  "traces": [
+    {
+      "createValueNonZero": true
+    },
+    {
+      "callType": ["call"],
+      "callSighash": ["0x3598d8ab"],
+      "callValueNonZero": true
+    },
+    {
+      "suicideBalanceNonZero": true
+    }
+  ]
+}

--- a/crates/query/fixtures/ethereum/queries/trace_value_non_zero/result.json
+++ b/crates/query/fixtures/ethereum/queries/trace_value_non_zero/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02c2c84a41eec2e10ec66ee53628660a9b067694d07abd165fb076492889742c
+size 33225

--- a/crates/query/fixtures/ethereum/queries/trace_value_non_zero/result.json
+++ b/crates/query/fixtures/ethereum/queries/trace_value_non_zero/result.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02c2c84a41eec2e10ec66ee53628660a9b067694d07abd165fb076492889742c
-size 33225
+oid sha256:60046d9f03d0cbde99348304c1b2c74be956e06c10d9eb16d1fa033df6f6b69e
+size 33477

--- a/crates/query/src/query/eth.rs
+++ b/crates/query/src/query/eth.rs
@@ -604,6 +604,9 @@ impl TraceRequest {
             to_lowercase_list(&self.suicide_refund_address)
         );
         p.col_in_list("reward_author", to_lowercase_list(&self.reward_author));
+
+        // Hex values are stored in minimal form (no leading zeros),
+        // so "0x01" never exists in the data.
         if self.call_value_non_zero {
             p.col_gt_eq("call_value", Some("0x1"));
         }

--- a/crates/query/src/query/eth.rs
+++ b/crates/query/src/query/eth.rs
@@ -574,6 +574,7 @@ request! {
         pub call_from: Option<Vec<Bytes>>,
         pub call_to: Option<Vec<Bytes>>,
         pub call_sighash: Option<Vec<Bytes>>,
+        pub call_type: Option<Vec<String>>,
         pub suicide_address: Option<Vec<Bytes>>,
         pub suicide_refund_address: Option<Vec<Bytes>>,
         pub reward_author: Option<Vec<Bytes>>,
@@ -592,6 +593,7 @@ impl TraceRequest {
         p.col_in_list("call_from", to_lowercase_list(&self.call_from));
         p.col_in_list("call_to", to_lowercase_list(&self.call_to));
         p.col_in_list("call_sighash", to_lowercase_list(&self.call_sighash));
+        p.col_in_list("call_type", self.call_type.as_deref());
         p.col_in_list("suicide_address", to_lowercase_list(&self.suicide_address));
         p.col_in_list(
             "suicide_refund_address",

--- a/crates/query/src/query/eth.rs
+++ b/crates/query/src/query/eth.rs
@@ -571,13 +571,17 @@ request! {
         pub r#type: Option<Vec<String>>,
         pub create_from: Option<Vec<Bytes>>,
         pub create_result_address: Option<Vec<Bytes>>,
+        pub create_value_non_zero: bool,
         pub call_from: Option<Vec<Bytes>>,
         pub call_to: Option<Vec<Bytes>>,
         pub call_sighash: Option<Vec<Bytes>>,
         pub call_type: Option<Vec<String>>,
+        pub call_value_non_zero: bool,
         pub suicide_address: Option<Vec<Bytes>>,
         pub suicide_refund_address: Option<Vec<Bytes>>,
+        pub suicide_balance_non_zero: bool,
         pub reward_author: Option<Vec<Bytes>>,
+        pub reward_value_non_zero: bool,
         pub transaction: bool,
         pub transaction_logs: bool,
         pub subtraces: bool,
@@ -600,6 +604,18 @@ impl TraceRequest {
             to_lowercase_list(&self.suicide_refund_address)
         );
         p.col_in_list("reward_author", to_lowercase_list(&self.reward_author));
+        if self.call_value_non_zero {
+            p.col_gt_eq("call_value", Some("0x1"));
+        }
+        if self.create_value_non_zero {
+            p.col_gt_eq("create_value", Some("0x1"));
+        }
+        if self.suicide_balance_non_zero {
+            p.col_gt_eq("suicide_balance", Some("0x1"));
+        }
+        if self.reward_value_non_zero {
+            p.col_gt_eq("reward_value", Some("0x1"));
+        }
     }
 
     fn relations(&self, scan: &mut ScanBuilder) {

--- a/crates/query/src/query/eth.rs
+++ b/crates/query/src/query/eth.rs
@@ -575,7 +575,7 @@ request! {
         pub call_from: Option<Vec<Bytes>>,
         pub call_to: Option<Vec<Bytes>>,
         pub call_sighash: Option<Vec<Bytes>>,
-        pub call_type: Option<Vec<String>>,
+        pub call_call_type: Option<Vec<String>>,
         pub call_value_non_zero: bool,
         pub suicide_address: Option<Vec<Bytes>>,
         pub suicide_refund_address: Option<Vec<Bytes>>,
@@ -597,7 +597,7 @@ impl TraceRequest {
         p.col_in_list("call_from", to_lowercase_list(&self.call_from));
         p.col_in_list("call_to", to_lowercase_list(&self.call_to));
         p.col_in_list("call_sighash", to_lowercase_list(&self.call_sighash));
-        p.col_in_list("call_type", self.call_type.as_deref());
+        p.col_in_list("call_type", self.call_call_type.as_deref());
         p.col_in_list("suicide_address", to_lowercase_list(&self.suicide_address));
         p.col_in_list(
             "suicide_refund_address",


### PR DESCRIPTION
This pr targets a use case where a user wants to get all traces that have non empty and not zero value. I concluded that `col_gt_eq` predicate + `0x1` hex value works better than anything else but i'm a bit concerned that it doesn't allow (for example) to specify min or max number to be filtered out - potentially we could try to parse a hex number into a number and compare it to a predicate value but it comes with overhead so i didn't follow that approach