### PR TITLE
Bound RocksDB info log growth in data-hotblocks NET-818

### DIFF
--- a/crates/hotblocks/src/cli.rs
+++ b/crates/hotblocks/src/cli.rs
@@ -53,6 +53,14 @@ pub struct CLI {
     #[arg(long)]
     pub rocksdb_disable_direct_io: bool,
 
+    /// Max size of a single RocksDB info log file in MB (0 - unlimited)
+    #[arg(long, value_name = "MB", default_value = "10")]
+    pub rocksdb_max_log_file_size: usize,
+
+    /// Max number of RocksDB info log files to keep
+    #[arg(long, value_name = "N", default_value = "10")]
+    pub rocksdb_keep_log_file_num: usize,
+
     /// Known client IDs for metrics labeling. Client IDs not in this list
     /// will be reported as "unknown" to prevent metrics cardinality abuse.
     #[arg(long = "known-client", value_name = "ID")]
@@ -76,6 +84,8 @@ impl CLI {
             .with_data_cache_size(self.data_cache_size)
             .with_rocksdb_stats(self.rocksdb_stats)
             .with_direct_io(!self.rocksdb_disable_direct_io)
+            .with_max_log_file_size(self.rocksdb_max_log_file_size)
+            .with_keep_log_file_num(self.rocksdb_keep_log_file_num)
             .open(&self.database_dir)
             .map(Arc::new)
             .context("failed to open rocksdb database")?;

--- a/crates/storage/src/db/db.rs
+++ b/crates/storage/src/db/db.rs
@@ -34,7 +34,9 @@ pub struct DatabaseSettings {
     data_cache_size: usize,
     with_rocksdb_stats: bool,
     direct_io: bool,
-    cache_index_and_filter_blocks: bool
+    cache_index_and_filter_blocks: bool,
+    max_log_file_size: usize,
+    keep_log_file_num: usize
 }
 
 impl Default for DatabaseSettings {
@@ -44,7 +46,9 @@ impl Default for DatabaseSettings {
             data_cache_size: 256,
             with_rocksdb_stats: false,
             direct_io: false,
-            cache_index_and_filter_blocks: false
+            cache_index_and_filter_blocks: false,
+            max_log_file_size: 10,
+            keep_log_file_num: 10
         }
     }
 }
@@ -75,11 +79,26 @@ impl DatabaseSettings {
         self
     }
 
+    /// Max size of a single info log file in MB (0 means unlimited)
+    pub fn with_max_log_file_size(mut self, mb: usize) -> Self {
+        self.max_log_file_size = mb;
+        self
+    }
+
+    /// Max number of info log files to keep
+    pub fn with_keep_log_file_num(mut self, count: usize) -> Self {
+        self.keep_log_file_num = count;
+        self
+    }
+
     fn db_options(&self) -> RocksOptions {
         let mut options = RocksOptions::default();
         options.create_if_missing(true);
         options.create_missing_column_families(true);
         options.set_wal_compression_type(rocksdb::DBCompressionType::Zstd);
+        // Bound info log (LOG, LOG.old.*) growth
+        options.set_max_log_file_size(self.max_log_file_size * 1024 * 1024);
+        options.set_keep_log_file_num(self.keep_log_file_num);
         if self.with_rocksdb_stats {
             options.enable_statistics();
         }


### PR DESCRIPTION
Sets `max_log_file_size` (10 MB) and `keep_log_file_num` (10) in the RocksDB options used by `data-hotblocks`, capping info log (`LOG` / `LOG.old.*`) disk usage at ~100 MB per database.

Previously these were left at RocksDB defaults (`max_log_file_size = 0` — single unbounded `LOG` file, plus `LOG.old.*` rotated on every reopen with `keep_log_file_num = 1000`), which let info logs accumulate unboundedly — the incident cleanup removed ~111 GB from db-0 and ~107 GB from db-1.

Closes [NET-818](https://linear.app/sqd-ai/issue/NET-818/bound-rocksdb-info-log-growth-in-data-hotblocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)