### PR TITLE
feat(metrics): make ingest errors, fork signals and epoch parks countable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,6 +4878,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "prometheus-client 0.24.0",
  "sqd-data-client",
  "sqd-primitives",
  "tokio",

--- a/crates/data-client/src/reqwest/client.rs
+++ b/crates/data-client/src/reqwest/client.rs
@@ -226,6 +226,46 @@ impl DataClient for ReqwestDataClient {
     fn is_retryable(&self, err: &anyhow::Error) -> bool {
         self.is_retryable(err)
     }
+
+    fn error_kind(&self, err: &anyhow::Error) -> &'static str {
+        for cause in err.chain() {
+            if cause.downcast_ref::<UnexpectedHttpStatus>().is_some() {
+                return "http";
+            }
+            if let Some(reqwest_error) = cause.downcast_ref::<reqwest::Error>() {
+                if reqwest_error.is_timeout() {
+                    return "timeout";
+                }
+                if reqwest_error.is_connect() {
+                    return "connect";
+                }
+                if reqwest_error.is_status() {
+                    return "http";
+                }
+                if reqwest_error.is_body() || reqwest_error.is_decode() {
+                    return "decode";
+                }
+                if reqwest_error.is_request() {
+                    return "request";
+                }
+            }
+            if cause.downcast_ref::<std::io::Error>().is_some() {
+                return "io";
+            }
+        }
+        "other"
+    }
+
+    // Host alone collapses endpoints that differ only by port or dataset path. Built by hand
+    // rather than from `Url::authority()`, which carries userinfo straight into the label.
+    fn source_label(&self) -> String {
+        let host = self.url.host_str().unwrap_or("unknown");
+        let path = self.url.path().trim_end_matches('/');
+        match self.url.port() {
+            Some(port) => format!("{host}:{port}{path}"),
+            None => format!("{host}{path}")
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/data-client/src/types.rs
+++ b/crates/data-client/src/types.rs
@@ -45,4 +45,14 @@ pub trait DataClient: Send + Sync + Debug + Unpin {
     fn get_finalized_head(&self) -> BoxFuture<'static, anyhow::Result<Option<BlockRef>>>;
 
     fn is_retryable(&self, err: &anyhow::Error) -> bool;
+
+    /// Error class for the `ingest_source_errors` metric label.
+    fn error_kind(&self, _err: &anyhow::Error) -> &'static str {
+        "other"
+    }
+
+    /// Source identity (host) for the `ingest_source_errors` metric label.
+    fn source_label(&self) -> String {
+        "unknown".to_string()
+    }
 }

--- a/crates/data-source/Cargo.toml
+++ b/crates/data-source/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }
+prometheus-client = { workspace = true }
 sqd-data-client = { path = "../data-client" }
 sqd-primitives = { path = "../primitives" }
 tokio = { workspace = true }

--- a/crates/data-source/src/lib.rs
+++ b/crates/data-source/src/lib.rs
@@ -1,4 +1,5 @@
 mod map;
+pub mod metrics;
 mod standard;
 mod types;
 

--- a/crates/data-source/src/metrics.rs
+++ b/crates/data-source/src/metrics.rs
@@ -1,0 +1,29 @@
+use std::sync::LazyLock;
+
+use prometheus_client::metrics::{counter::Counter, family::Family};
+
+type Labels = Vec<(&'static str, String)>;
+
+/// Upstream data-source ingestion errors by `source` endpoint and `kind`.
+/// Registered in the hotblocks metrics registry.
+pub static INGEST_SOURCE_ERRORS: LazyLock<Family<Labels, Counter>> = LazyLock::new(Default::default);
+
+/// Fork signals by `source` and whether it held the contested position (`at_tip`/`above_tip`).
+pub static INGEST_FORK_SIGNALS: LazyLock<Family<Labels, Counter>> = LazyLock::new(Default::default);
+
+/// Public because the pre-ingest head probe lives in `hotblocks` and must feed the same counter:
+/// it runs before this crate's stream loop, so a total outage never reaches `on_error`.
+pub fn record_ingest_source_error(source: &str, kind: &'static str) {
+    INGEST_SOURCE_ERRORS
+        .get_or_create(&vec![("source", source.to_string()), ("kind", kind.to_string())])
+        .inc();
+}
+
+pub(crate) fn record_ingest_fork_signal(source: &str, standing: &'static str) {
+    INGEST_FORK_SIGNALS
+        .get_or_create(&vec![
+            ("source", source.to_string()),
+            ("standing", standing.to_string()),
+        ])
+        .inc();
+}

--- a/crates/data-source/src/standard.rs
+++ b/crates/data-source/src/standard.rs
@@ -77,11 +77,10 @@ impl<F> DataSourceState<F> {
                         }
                     }
                     Poll::Ready(Ok(BlockStreamResponse::Fork(prev_blocks))) => {
+                        let req = req.clone();
+                        ep.on_fork_signal(req.first_block, &prev_blocks);
                         ep.error_counter = 0;
-                        ep.state = EndpointState::Fork {
-                            req: req.clone(),
-                            prev_blocks
-                        };
+                        ep.state = EndpointState::Fork { req, prev_blocks };
                     }
                     Poll::Ready(Err(err)) => ep.on_error(err),
                     Poll::Pending => return Poll::Pending
@@ -220,7 +219,20 @@ impl<C: DataClient> Endpoint<C> {
         }
     }
 
+    // A source answers 409 only at `head + 1 == from`, so in-spec hints top out at `from - 1`.
+    fn on_fork_signal(&self, from: BlockNumber, prev_blocks: &[BlockRef]) {
+        let standing = match prev_blocks.last() {
+            Some(top) if top.number < from.saturating_sub(1) => "above_tip",
+            // Empty hints are a malformed 409 the reqwest client already rejects; counting them
+            // as `at_tip` keeps the defect bucket clean of shapes it cannot speak to.
+            _ => "at_tip"
+        };
+        crate::metrics::record_ingest_fork_signal(&self.client.source_label(), standing);
+    }
+
     fn on_error(&mut self, error: anyhow::Error) {
+        crate::metrics::record_ingest_source_error(&self.client.source_label(), self.client.error_kind(&error));
+
         let backoff = [0, 100, 200, 500, 1000, 2000, 5000, 10000];
         let pause = backoff[std::cmp::min(self.error_counter, backoff.len() - 1)];
         if pause > 0 {

--- a/crates/hotblocks/src/dataset_controller/dataset_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/dataset_controller.rs
@@ -2,7 +2,7 @@ use std::{ops::Add, time::Duration};
 
 use anyhow::{Context, anyhow};
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
-use sqd_data_client::reqwest::ReqwestDataClient;
+use sqd_data_client::{DataClient, reqwest::ReqwestDataClient};
 use sqd_primitives::{BlockNumber, BlockRef, TransactionRef};
 use sqd_storage::db::{CompactionStatus, DatasetId};
 use tokio::{select, task::JoinHandle, time::Instant};
@@ -248,6 +248,7 @@ impl Ctl {
             match self.write_epoch(std::mem::take(&mut maybe_write)).await {
                 Ok(_) => return,
                 Err(err) => {
+                    crate::metrics::report_dataset_epoch_failure(self.dataset_id, &err);
                     error!(reason = ?err, "dataset update task failed, will restart it in 1 minute");
                     tokio::time::sleep(Duration::from_secs(60)).await
                 }
@@ -489,6 +490,14 @@ async fn fetch_chain_top(clients: Vec<ReqwestDataClient>) -> BlockNumber {
                         }
                     },
                     Some((Err(err), ci)) => {
+                        // The probe gates ingestion, and its only exit on total failure is
+                        // `completed > 0`. With every source down it spins here forever, so
+                        // `on_error` never runs and the counter would read zero through the
+                        // whole stall — the one outage it exists to expose.
+                        sqd_data_source::metrics::record_ingest_source_error(
+                            &clients[ci].source_label(),
+                            clients[ci].error_kind(&err)
+                        );
                         if clients[ci].is_retryable(&err) {
                             warn!(
                                 reason =? err,

--- a/crates/hotblocks/src/dataset_controller/write_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/write_controller.rs
@@ -8,6 +8,7 @@ use tracing::{debug, field::valuable, info, instrument, warn};
 
 use crate::{
     dataset_controller::ingest_generic::{IngestMessage, NewChunk},
+    errors::UnapplicableFork,
     metrics::{WriteStage, report_hash_index_write_metrics, report_write_duration},
     types::{DBRef, DatasetKind}
 };
@@ -139,10 +140,17 @@ impl WriteController {
         if let Some(finalized_head) = label.finalized_head() {
             let pos = match prev.iter().position(|b| b.number >= finalized_head.number) {
                 Some(pos) => pos,
-                None => bail!("all passed prev blocks lie below finalized head")
+                None => bail!(UnapplicableFork {
+                    reason: "all passed prev blocks lie below finalized head"
+                })
             };
             if prev[pos].number == finalized_head.number {
-                ensure!(prev[pos].hash == finalized_head.hash);
+                ensure!(
+                    prev[pos].hash == finalized_head.hash,
+                    UnapplicableFork {
+                        reason: "fork disagrees with the finalized head hash"
+                    }
+                );
             }
             prev = &prev[pos..]
         }

--- a/crates/hotblocks/src/errors.rs
+++ b/crates/hotblocks/src/errors.rs
@@ -38,6 +38,20 @@ impl Display for QueryTaskPanicked {
 
 impl std::error::Error for QueryTaskPanicked {}
 
+/// Divergence reaching below finalized data. Kills the update task, which then parks for a minute.
+#[derive(Debug)]
+pub struct UnapplicableFork {
+    pub reason: &'static str
+}
+
+impl Display for UnapplicableFork {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "received fork can not be applied: {}", self.reason)
+    }
+}
+
+impl std::error::Error for UnapplicableFork {}
+
 #[derive(Debug)]
 pub struct UnknownDataset {
     pub dataset_id: DatasetId

--- a/crates/hotblocks/src/metrics.rs
+++ b/crates/hotblocks/src/metrics.rs
@@ -18,7 +18,7 @@ use sqd_storage::db::{
 };
 use tracing::error;
 
-use crate::{query::QueryExecutorCollector, types::DBRef};
+use crate::{errors::UnapplicableFork, query::QueryExecutorCollector, types::DBRef};
 
 #[derive(Copy, Clone, Hash, Debug, Default, Ord, PartialOrd, Eq, PartialEq, EncodeLabelSet)]
 struct DatasetLabel {
@@ -127,6 +127,29 @@ struct WriteLabels {
     dataset: DatasetValue,
     stage: WriteStage,
     outcome: WriteOutcome
+}
+
+#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq, EncodeLabelSet)]
+struct EpochFailureLabels {
+    dataset: DatasetValue,
+    reason: &'static str
+}
+
+static DATASET_EPOCH_FAILURES: LazyLock<Family<EpochFailureLabels, Counter>> = LazyLock::new(Default::default);
+
+pub(crate) fn report_dataset_epoch_failure(dataset_id: DatasetId, err: &anyhow::Error) {
+    // Never label by message — it carries block numbers and hashes.
+    let reason = if err.chain().any(|e| e.is::<UnapplicableFork>()) {
+        "unapplicable_fork"
+    } else {
+        "other"
+    };
+    DATASET_EPOCH_FAILURES
+        .get_or_create(&EpochFailureLabels {
+            dataset: DatasetValue(dataset_id),
+            reason
+        })
+        .inc();
 }
 
 static WRITE_DURATION: LazyLock<Family<WriteLabels, Histogram>> =
@@ -462,6 +485,31 @@ pub fn build_metrics_registry() -> Registry {
         "query_error_worker_panic",
         "Number of query worker panics that aborted an in-flight response stream",
         QUERY_ERROR_WORKER_PANIC.clone()
+    );
+
+    registry.register(
+        "ingest_source_errors",
+        "Upstream data source ingestion errors, by source endpoint (host:port/path) and kind \
+         (connect/timeout/http/decode/io/request/other). Covers both the pre-ingest head probe \
+         and the stream loop",
+        sqd_data_source::metrics::INGEST_SOURCE_ERRORS.clone()
+    );
+
+    registry.register(
+        "ingest_fork_signals",
+        "Fork signals from upstream data sources, by source endpoint and whether the source \
+         held the contested position (standing=at_tip) or contested one above its own tip \
+         (standing=above_tip). GAP-21: an honest source can also land in above_tip when its \
+         hint window misses the parent across a hole wider than 100 positions",
+        sqd_data_source::metrics::INGEST_FORK_SIGNALS.clone()
+    );
+
+    registry.register(
+        "dataset_epoch_failures",
+        "Dataset update task failures, by dataset and cause; each one parks ingestion for \
+         60s before a full restart. reason=unapplicable_fork is a divergence reaching below \
+         finalized data",
+        DATASET_EPOCH_FAILURES.clone()
     );
 
     registry.register("http_status", "Number of sent HTTP responses", HTTP_STATUS.clone());

--- a/crates/hotblocks/tests/ct4_lagging_source.rs
+++ b/crates/hotblocks/tests/ct4_lagging_source.rs
@@ -193,3 +193,87 @@ async fn ct4_a_caught_up_source_changes_nothing() -> Result<()> {
 
     Ok(())
 }
+
+/// The wedge above is invisible twice over: the fork signal is an `Ok` that never reaches
+/// `on_error`, and the park is an `error!` a crash-looping pod may never ship. Neither GAP-41 nor
+/// GAP-5 is fixed here — this pins that both became countable, so a head held back by a lying
+/// source reads differently from a hung service.
+///
+/// Not `#[ignore]`d unlike its neighbours: observability holds, conformance does not.
+#[tokio::test(flavor = "multi_thread")]
+async fn ct4_a_fork_signal_above_the_tip_and_the_park_it_causes_are_observable() -> Result<()> {
+    let mut h = Harness::start(config(3)).await?;
+
+    h.produce(20)?;
+    h.finalize_with_lag(5)?;
+    h.settle().await?;
+
+    for peer in &h.peers {
+        peer.inject_fault(&h.dataset, |f| f.fork_signal_above_tip = true);
+    }
+
+    for _ in 0..12 {
+        h.produce_ahead(10)?;
+        h.finalize_with_lag(5)?;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // No `settle` — the epoch is serving out `P-EPOCH-RETRY`, which is the thing being measured.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let metrics = h.client.metrics().await?;
+
+    let above_tip = metrics
+        .get("hotblocks_ingest_fork_signals_total", Some(("standing", "above_tip")))
+        .unwrap_or_default();
+    assert!(above_tip > 0.0, "a fork signalled above the source's own tip");
+
+    assert!(
+        metrics
+            .get("hotblocks_ingest_fork_signals_total", Some(("standing", "at_tip")))
+            .is_none(),
+        "no source held the contested position"
+    );
+
+    let parked = metrics
+        .get(
+            "hotblocks_dataset_epoch_failures_total",
+            Some(("reason", "unapplicable_fork"))
+        )
+        .unwrap_or_default();
+    assert!(parked > 0.0, "the park must name the divergence as its cause");
+
+    Ok(())
+}
+
+/// The other half: an honest reorg must land in `at_tip`. Without it the label above is
+/// unfalsifiable — a discriminator stuck on `above_tip` would pass that script and then cry
+/// source defect on every ordinary reorg in production.
+#[tokio::test(flavor = "multi_thread")]
+async fn ct4_an_honest_reorg_is_not_attributed_to_the_source() -> Result<()> {
+    let mut h = Harness::start(config(1)).await?;
+
+    h.produce(20)?;
+    h.settle().await?;
+
+    h.fork(1_010, 10)?;
+    h.finalize_with_lag(5)?;
+    h.settle().await?;
+    h.assert_conforms().await?;
+
+    let metrics = h.client.metrics().await?;
+
+    let at_tip = metrics
+        .get("hotblocks_ingest_fork_signals_total", Some(("standing", "at_tip")))
+        .unwrap_or_default();
+    assert!(at_tip > 0.0, "the reorg reaches the service as a fork signal");
+
+    assert!(
+        metrics
+            .get("hotblocks_ingest_fork_signals_total", Some(("standing", "above_tip")))
+            .is_none(),
+        "the source signalled where it stood — attributing this to a defect would make the \
+         metric fire on every reorg"
+    );
+
+    Ok(())
+}

--- a/crates/hotblocks/tests/ct9_source_faults.rs
+++ b/crates/hotblocks/tests/ct9_source_faults.rs
@@ -9,8 +9,10 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use sqd_hotblocks_harness::{
-    chain::HlFills,
-    harness::{Harness, HarnessConfig}
+    chain::{Chain, Evm, HlFills},
+    driver::Client,
+    harness::{Harness, HarnessConfig},
+    sut::{DatasetSpec, Retention, Sut, SutConfig}
 };
 
 const START: u64 = 1_000;
@@ -53,4 +55,59 @@ async fn run(h: &mut Harness) -> Result<()> {
         "sanity: the service was never restarted by the harness"
     );
     Ok(())
+}
+
+/// Total outage is the one source fault the ingest counter could not see. The head probe gates
+/// ingestion and its only exit on total failure is `completed > 0`, so with every source down it
+/// spins there forever, `StandardDataSource` is never constructed and `on_error` never runs — the
+/// counter would read zero through precisely the outage it exists to expose, while the service
+/// stays up and scraped.
+///
+/// The assertion keys on `source` rather than `kind` so it also pins the label as the full
+/// endpoint: a host-only label collapses every source of every dataset into one series.
+#[tokio::test(flavor = "multi_thread")]
+async fn ct9_a_total_source_outage_is_counted_before_ingestion_starts() -> Result<()> {
+    const DS: &str = "outage";
+
+    // Bound to claim a port, then released: probes are refused rather than left hanging.
+    let dead = std::net::TcpListener::bind("127.0.0.1:0")?.local_addr()?.port();
+
+    let sut = Sut::start(SutConfig::new(
+        env!("CARGO_BIN_EXE_sqd-hotblocks"),
+        vec![DatasetSpec {
+            id: DS.to_string(),
+            kind: Evm.config_kind().to_string(),
+            // `Head` is what routes the dataset through the probe at all.
+            retention: Retention::Head(100),
+            sources: vec![format!("http://127.0.0.1:{dead}/{DS}")]
+        }]
+    ))
+    .await?;
+
+    let client = Client::new(sut.base_url(), DS)?;
+    let source = format!("127.0.0.1:{dead}/{DS}");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+
+    loop {
+        let metrics = client.metrics().await?;
+        if metrics
+            .get("hotblocks_ingest_source_errors_total", Some(("source", &source)))
+            .unwrap_or_default()
+            > 0.0
+        {
+            assert!(
+                metrics
+                    .get("hotblocks_ingest_source_errors_total", Some(("kind", "connect")))
+                    .unwrap_or_default()
+                    > 0.0,
+                "a refused connection must classify as `connect`"
+            );
+            return Ok(());
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "ingestion stalled on an unreachable source without counting a single error"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }


### PR DESCRIPTION
## What

Three counters over the ingest path, which had none.

| metric | labels |
|---|---|
| `hotblocks_ingest_source_errors_total` | `source`, `kind` — `connect`/`timeout`/`http`/`decode`/`io`/`request`/`other` |
| `hotblocks_ingest_fork_signals_total` | `source`, `standing` — `at_tip`/`above_tip` |
| `hotblocks_dataset_epoch_failures_total` | `dataset`, `reason` — `unapplicable_fork`/`other` |

`source` is the configured endpoint as `host:port/path`, not the host. Host alone collapses
endpoints that differ only by port or dataset path into a single series, which defeats the whole
point of a per-source label — and since the configured URL carries the dataset in its path, the
full endpoint gives per-dataset attribution without plumbing a `dataset` label through
`data-source`. It is assembled by hand rather than from `Url::authority()`, which would put
userinfo into a Prometheus label.

## Why

**Transport errors** (DNS/connect failures, upstream 5xx, timeouts) were WARN logs only. A stalled
ingest — every source failing to connect — was invisible on dashboards and unalertable. A log line
cannot be alerted on, cannot be aggregated across pods, and is gone from the tail once a restart
loop has rolled it away; Prometheus keeps scraping through all three.

**The head probe** is counted alongside the stream loop, because otherwise the counter is blind in
exactly the worst case. `fetch_chain_top` gates ingestion, and its only exit on total failure is
the `completed > 0` guard on the deadline arm: with every source down, `completed` stays zero, the
timeout is disabled and the probe respins on a 5s backoff forever. `StandardDataSource` is never
constructed, `on_error` never runs, and the counter reads zero through a total outage while a
partial one — strictly less severe — counts normally. This is not confined to `Head` retention;
`HeadProbe` runs whenever the init head is `Some`, which includes `Api` retention with
`max_blocks` set.

**Fork signals** were not covered by that counter, and by construction: a 409 arrives as
`Ok(BlockStreamResponse::Fork)`, never reaches `on_error`, and resets `error_counter` on the way
through. So the per-source error rate stays flat through the exact event that wedges ingestion —
GAP-41, where one lying endpoint of three parks the dataset while two healthy sources keep
offering the chain.

**Epoch deaths** were an `error!` log before a 60s park. A pod in a restart loop may never ship
it, which is the case where knowing matters most.

## The `standing` label

A plain fork counter would answer the wrong question — it fires on every ordinary reorg too. The
split is strict rather than heuristic:

`query/service.rs:128` answers 409 **only** at `head.number + 1 == query.first_block()`, otherwise
it waits. So an in-spec hint chain always tops out at `from - 1`, and a top hint below that means
the source contested a position it does not itself hold. That is exactly the harness fault's
definition (`sim.rs:370`), and exactly the GAP-41 shape: the adopted hints end at the liar's stale
tip, `compute_rollback` rejects them as below `fin`, ingestion parks.

The other two hint-building paths agree: `query/running.rs:172` emits
`first_chunk.first_block() - 1` gated on equality with `query.first_block()`, and
`plan.rs:136` upper-bounds its window at `parent_number = from - 1` (sparse chains) or
`number = from` (dense), sorting ascending so `last()` is the top. One caveat, recorded in the
metric's help text: **GAP-21** — the 100-position hint window can miss the parent across a wider
hole, and an honest source then lands in `above_tip`. Documented as unlikely when nothing consumed
it; worth knowing now that it is alertable.

```promql
# which source is signalling forks it has no standing for
sum by (source, standing) (rate(hotblocks_ingest_fork_signals_total[5m]))

# are we parking in production, and on what
sum by (dataset, reason) (rate(hotblocks_dataset_epoch_failures_total[5m]))

# distinct sources erroring — spikes on a real incident, flat against a chronic-dead baseline
count by (pod) (sum by (pod, source) (rate(hotblocks_ingest_source_errors_total{kind="connect"}[5m])) > 0)
```

## Notes

`reason` buckets off a typed `UnapplicableFork`, not the error text — the message carries block
numbers and hashes, so it can never become a label, and string matching would break silently on a
rewording. It also gives the previously anonymous `ensure!(prev[pos].hash == finalized_head.hash)`
a name.

`DataClient::error_kind()` / `source_label()` are trait methods with default impls (`"other"` /
`"unknown"`); the reqwest-specific classification stays in `ReqwestDataClient`.

Recording stays at the call sites rather than moving inside `ReqwestDataClient`. A client-level
recorder would catch every call path automatically, but `on_error` also counts errors that never
came from the client — `failed to parse a block` is wrapped there — so it would either lose those
or need both layers recording and a rule about which owns what. The probe and the stream loop are
sequential states of one controller loop, so there is no double count.

## Tests

`ct4_lagging_source.rs` pins the discriminator from both sides — a defect lands in `above_tip` with
`at_tip` empty, an honest reorg the reverse. One test would not do: a discriminator stuck on
`above_tip` passes the first script and then cries source defect on every reorg in production.
Verified by inverting the comparison, which fails the suite.

`ct9_source_faults.rs` covers the probe: a dataset whose only source is an unreachable port must
count the failure even though ingestion never starts. It keys on the `source` label rather than
`kind`, so it pins the endpoint label format at the same time.

The observability tests are not `#[ignore]`d, unlike their two GAP-41 neighbours — observability
holds, conformance does not.

## Scope

Nothing is fixed here. GAP-41 and GAP-5 both remain: one lying source of three still parks
ingestion, with no alarm and no recovery. This only makes that state countable, so a head held
back by a bad source reads differently from a hung service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
