### PR TITLE
feat(metrics): RocksDB write-stall gauges

### DIFF
--- a/crates/hotblocks/src/cli.rs
+++ b/crates/hotblocks/src/cli.rs
@@ -10,7 +10,7 @@ use sqd_storage::db::{DatabaseSettings, DatasetId};
 use crate::{
     data_service::{DataService, DataServiceRef},
     dataset_config::{DatasetConfig, RetentionConfig},
-    metrics::DatasetMetricsCollector,
+    metrics::{DatasetMetricsCollector, RocksDbCollector},
     query::{QueryService, QueryServiceRef},
     types::DBRef
 };
@@ -125,6 +125,7 @@ impl CLI {
             db: db.clone(),
             datasets: datasets.keys().copied().collect()
         }));
+        metrics_registry.register_collector(Box::new(RocksDbCollector { db: db.clone() }));
 
         let api_controlled_datasets = datasets
             .iter()

--- a/crates/hotblocks/src/metrics.rs
+++ b/crates/hotblocks/src/metrics.rs
@@ -12,7 +12,7 @@ use prometheus_client::{
     },
     registry::Registry
 };
-use sqd_storage::db::{DatasetId, ReadSnapshot};
+use sqd_storage::db::{CF_CHUNKS, CF_TABLES, DatasetId, ReadSnapshot};
 use tracing::error;
 
 use crate::{query::QueryExecutorCollector, types::DBRef};
@@ -164,6 +164,105 @@ fn collect_dataset_metrics(
         )?
         .encode_family(&dataset_label!(dataset_id))?
         .encode_gauge(&label.finalized_head().map_or(0, |h| h.number))?;
+
+    Ok(())
+}
+
+/// RocksDB write-stall / LSM-backlog gauges, read from intrinsic properties on scrape.
+/// One shared WriteController: any CF's stall stops the whole DB, so DB-wide gauges are global.
+#[derive(Debug)]
+pub struct RocksDbCollector {
+    pub db: DBRef
+}
+
+// (metric, help, property) -- DB-global, queried on one CF.
+const ROCKSDB_DB_WIDE: &[(&str, &str, &str)] = &[
+    (
+        "hotblocks_rocksdb_write_stopped",
+        "1 while RocksDB has hard-stopped all writes",
+        "rocksdb.is-write-stopped"
+    ),
+    (
+        "hotblocks_rocksdb_actual_delayed_write_rate",
+        "Throttled write rate in bytes/s while writes are delayed (soft stall); 0 when not delayed",
+        "rocksdb.actual-delayed-write-rate"
+    ),
+    (
+        "hotblocks_rocksdb_running_compactions",
+        "Compactions currently running",
+        "rocksdb.num-running-compactions"
+    ),
+    (
+        "hotblocks_rocksdb_running_flushes",
+        "Memtable flushes currently running",
+        "rocksdb.num-running-flushes"
+    )
+];
+
+// (metric, help, property) -- per-cf backlog that trips a stall.
+const ROCKSDB_PER_CF: &[(&str, &str, &str)] = &[
+    (
+        "hotblocks_rocksdb_num_files_at_level0",
+        "SST files at L0 (stalls writes once it reaches level0_stop_writes_trigger)",
+        "rocksdb.num-files-at-level0"
+    ),
+    (
+        "hotblocks_rocksdb_estimate_pending_compaction_bytes",
+        "Estimated bytes pending compaction (stalls writes at the soft/hard limit)",
+        "rocksdb.estimate-pending-compaction-bytes"
+    ),
+    (
+        "hotblocks_rocksdb_num_immutable_mem_table",
+        "Immutable memtables not yet flushed",
+        "rocksdb.num-immutable-mem-table"
+    ),
+    (
+        "hotblocks_rocksdb_mem_table_flush_pending",
+        "1 while a memtable flush is pending",
+        "rocksdb.mem-table-flush-pending"
+    )
+];
+
+const ROCKSDB_DATA_CFS: &[&str] = &[CF_CHUNKS, CF_TABLES];
+
+#[derive(Clone, Hash, Debug, Eq, PartialEq, EncodeLabelSet)]
+struct CfLabel {
+    cf: &'static str
+}
+
+impl Collector for RocksDbCollector {
+    fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+        if let Err(err) = collect_rocksdb_metrics(&mut encoder, &self.db) {
+            return if err.is::<std::fmt::Error>() {
+                Err(err.downcast().unwrap())
+            } else {
+                error!(err =? err, "failed to collect rocksdb metrics");
+                Ok(())
+            };
+        }
+        Ok(())
+    }
+}
+
+fn collect_rocksdb_metrics(encoder: &mut DescriptorEncoder, db: &DBRef) -> anyhow::Result<()> {
+    for (metric, help, prop) in ROCKSDB_DB_WIDE {
+        if let Some(value) = db.get_int_property(CF_TABLES, prop)? {
+            encoder
+                .encode_descriptor(metric, help, None, MetricType::Gauge)?
+                .encode_gauge(&value)?;
+        }
+    }
+
+    for (metric, help, prop) in ROCKSDB_PER_CF {
+        for &cf in ROCKSDB_DATA_CFS {
+            if let Some(value) = db.get_int_property(cf, prop)? {
+                encoder
+                    .encode_descriptor(metric, help, None, MetricType::Gauge)?
+                    .encode_family(&CfLabel { cf })?
+                    .encode_gauge(&value)?;
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/storage/src/db/db.rs
+++ b/crates/storage/src/db/db.rs
@@ -396,6 +396,14 @@ impl Database {
         let val = self.db.property_value_cf(cf_handle, name)?;
         Ok(val)
     }
+
+    pub fn get_int_property(&self, cf: &str, name: &str) -> anyhow::Result<Option<u64>> {
+        let Some(cf_handle) = self.db.cf_handle(cf) else {
+            return Ok(None);
+        };
+        let val = self.db.property_int_value_cf(cf_handle, name)?;
+        Ok(val)
+    }
 }
 
 impl std::fmt::Debug for Database {

--- a/crates/storage/tests/rocksdb_properties.rs
+++ b/crates/storage/tests/rocksdb_properties.rs
@@ -1,0 +1,50 @@
+//! `get_int_property` backs the `hotblocks_rocksdb_*` gauges; it must work without
+//! `enable_statistics()` (prod default). Pins the property names -- a typo => silent None.
+
+use sqd_storage::db::{DatabaseSettings, CF_CHUNKS, CF_TABLES};
+
+const DB_WIDE_PROPS: &[&str] = &[
+    "rocksdb.is-write-stopped",
+    "rocksdb.actual-delayed-write-rate",
+    "rocksdb.num-running-compactions",
+    "rocksdb.num-running-flushes"
+];
+
+const PER_CF_PROPS: &[&str] = &[
+    "rocksdb.num-files-at-level0",
+    "rocksdb.estimate-pending-compaction-bytes",
+    "rocksdb.num-immutable-mem-table",
+    "rocksdb.mem-table-flush-pending"
+];
+
+#[test]
+fn int_properties_available_without_stats() {
+    let dir = tempfile::tempdir().unwrap();
+    // Default settings => rocksdb stats disabled, mirroring production.
+    let db = DatabaseSettings::default().open(dir.path()).unwrap();
+
+    for prop in DB_WIDE_PROPS {
+        assert!(
+            db.get_int_property(CF_TABLES, prop).unwrap().is_some(),
+            "db-wide property {prop} returned None"
+        );
+    }
+
+    for cf in [CF_CHUNKS, CF_TABLES] {
+        for prop in PER_CF_PROPS {
+            assert!(
+                db.get_int_property(cf, prop).unwrap().is_some(),
+                "property {prop} on cf {cf} returned None"
+            );
+        }
+    }
+
+    // A fresh database is not stalled.
+    assert_eq!(
+        db.get_int_property(CF_TABLES, "rocksdb.is-write-stopped").unwrap(),
+        Some(0)
+    );
+
+    // An unknown column family yields None rather than erroring.
+    assert_eq!(db.get_int_property("NOPE", "rocksdb.is-write-stopped").unwrap(), None);
+}


### PR DESCRIPTION
## Why

The post-deploy ingest freeze (all datasets freeze ~6 min, then resume together) looks like a **global RocksDB write-stall** on the shared `Arc<Database>`: RocksDB keeps one `WriteController` per DB, so a stall triggered by any single column family throttles writes DB-wide → every dataset freezes at once, releasing when compaction catches up. Retrospective telemetry can't show it — RocksDB's own stall state was never exported.

## What

`hotblocks_rocksdb_*` gauges via a pull-collector (`RocksDbCollector`). Reads intrinsic RocksDB properties on scrape only — no write-path cost, no `enable_statistics()` needed:
- DB-wide: `write_stopped` (decisive), `actual_delayed_write_rate`, `running_compactions`, `running_flushes`
- per-cf (`CHUNKS`, `TABLES`): `num_files_at_level0`, `estimate_pending_compaction_bytes`, `num_immutable_mem_table`, `mem_table_flush_pending`

Plus `Database::get_int_property` + a test pinning the property names (a typo → silent `None` → missing gauge).

## Verifying the freeze

On the next deploy/freeze, `hotblocks_rocksdb_write_stopped == 1` plus a spike in `num_files_at_level0` / `estimate_pending_compaction_bytes` confirms a write-stall and names the trigger. The existing `--rocksdb-max-background-jobs` flag is the lever to raise background jobs if the autodetected `2..=8` default is too low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
