### PR TITLE
ci(tests): run clippy/test on self-hosted, keep fork PRs sandboxed

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,12 +19,20 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    # Fork PRs run untrusted code, so they stay on GitHub-hosted and can never reach the
+    # self-hosted host. Everything else (in-repo branches, push, dispatch) uses the faster
+    # self-hosted runner with a warm cargo cache. Runner groups can't gate by trigger, so the
+    # split has to live here in the workflow — not in the approval setting.
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted", "dev-server"]') }}
     if: github.event_name == 'push' || !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Share the dependency cache between clippy and test instead of compiling deps twice.
+          shared-key: rust-ci
+          cache-on-failure: true
       - run: cargo clippy --all-targets --all-features -- -D clippy::correctness
 
   fmt:
@@ -40,7 +48,9 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    # Fork PRs stay on GitHub-hosted (untrusted code); trusted events use self-hosted. See the
+    # clippy job above for the rationale.
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted", "dev-server"]') }}
     if: github.event_name == 'push' || !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +58,9 @@ jobs:
           lfs: true
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-ci
+          cache-on-failure: true
       - name: Fetch LFS files
         run: git lfs fetch --all && git lfs checkout
       - name: Run tests


### PR DESCRIPTION
Companion to #86 (docker image build, already merged) — moves the *compiling* test jobs onto the same self-hosted runners.

## What
- `clippy` and `test` → `[self-hosted, dev-server]` for the 8-core speedup + warm cargo cache.
- `fmt` stays on `ubuntu-latest` (no compilation, nothing to gain).

## Security (this repo is PUBLIC)
Fork PRs run untrusted code. Runner groups can't gate by trigger, and the fork-PR approval gate is weak (returning contributors auto-run; approval fatigue). So a conditional `runs-on` keeps **fork PRs on `ubuntu-latest`** and routes only trusted events (in-repo branches, push, dispatch) to the self-hosted host:
```yaml
runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted", "dev-server"]') }}
```
Fork code therefore never reaches the dev box regardless of the approval setting.

## Cache
Swatinem `shared-key: rust-ci` so clippy and test share the dependency cache instead of compiling deps twice, plus `cache-on-failure`.

## Requires
`subsquid/data` access to the `dev-server` runner group (same as #86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)