### PR TITLE
feat(hotblocks): quiet the INFO firehose, fatten and flatten the startup event

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,15 +23,18 @@ jobs:
     # self-hosted host. Everything else (in-repo branches, push, dispatch) uses the faster
     # self-hosted runner with a warm cargo cache. Runner groups can't gate by trigger, so the
     # split has to live here in the workflow — not in the approval setting.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted", "dev-server"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted", "dev-server"]') }}
     if: github.event_name == 'push' || !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
         with:
-          # Share the dependency cache between clippy and test instead of compiling deps twice.
-          shared-key: rust-ci
+          # Not shared with `test`: clippy's target dir holds check-only artifacts (.rmeta),
+          # while `cargo test` needs full codegen. One key for both meant clippy always won
+          # the race to write the immutable key, so test restored a codegen-less cache and
+          # rebuilt the whole graph every run -- 52s for clippy against 20+ min for test.
+          shared-key: rust-ci-clippy
           cache-on-failure: true
       - run: cargo clippy --all-targets --all-features -- -D clippy::correctness
 
@@ -50,7 +53,7 @@ jobs:
     name: Test
     # Fork PRs stay on GitHub-hosted (untrusted code); trusted events use self-hosted. See the
     # clippy job above for the rationale.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted", "dev-server"]') }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted", "dev-server"]') }}
     if: github.event_name == 'push' || !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +62,7 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rust-ci
+          shared-key: rust-ci-test
           cache-on-failure: true
       - name: Fetch LFS files
         run: git lfs fetch --all && git lfs checkout

--- a/crates/hotblocks/src/api.rs
+++ b/crates/hotblocks/src/api.rs
@@ -111,7 +111,7 @@ pub async fn middleware(mut req: Request, next: axum::middleware::Next) -> impl 
     labels.push(("status", response.status().as_str().to_owned()));
 
     span.in_scope(|| {
-        tracing::info!(
+        tracing::debug!(
             target: "http_request",
             method,
             path,

--- a/crates/hotblocks/src/data_service.rs
+++ b/crates/hotblocks/src/data_service.rs
@@ -1,13 +1,14 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    sync::Arc
+    sync::Arc,
+    time::Instant
 };
 
 use anyhow::{Context, anyhow};
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use sqd_data_client::reqwest::ReqwestDataClient;
-use sqd_storage::db::DatasetId;
-use tracing::{debug, error, info, warn};
+use sqd_storage::db::{CF_TABLES, DatasetId};
+use tracing::{error, info, warn};
 
 use crate::{
     dataset_config::{DatasetConfig, RetentionConfig},
@@ -109,27 +110,29 @@ impl DataService {
 /// Does not rescue a volume at literally zero free bytes: the database has already opened
 /// by the time we get here, and opening replays the WAL and flushes it to L0.
 fn startup_disk_recovery(db: &DBRef, unconfigured: &[DatasetId], disk_reclaim: bool) {
+    let started = Instant::now();
+    let bytes_before = table_sst_bytes(db);
+
+    let mut orphans_purged = 0usize;
+    let mut unconfigured_deleted = 0usize;
+
     if disk_reclaim {
         if let Err(err) = db.reclaim_disk_space() {
             error!(error =? err, "startup disk reclaim (first pass) failed");
         }
 
         match db.purge_orphan_dirty_tables() {
-            Ok(0) => {}
-            Ok(n) => info!("purged {n} orphan dirty table(s) left by an interrupted build"),
+            Ok(n) => orphans_purged = n,
             Err(err) => warn!(error =? err, "failed to purge orphan dirty tables")
         }
-    } else {
-        // FUTURE: ungate the orphan purge once the rollout measurement is done. It is safe
-        // without the unlink, and while gated an interrupted build leaks its data for good;
-        // it shares the flag only so `reclaim-measure` can still contrast the two watermarks.
-        info!("startup disk reclaim is off; enable with --startup-disk-reclaim");
     }
 
     for dataset_id in unconfigured {
-        info!("deleting unconfigured dataset {dataset_id}");
-        if let Err(err) = db.delete_dataset(*dataset_id) {
-            error!("failed to delete dataset {dataset_id}: {err}; its chunks keep pinning the reclaim watermark");
+        match db.delete_dataset(*dataset_id) {
+            Ok(()) => unconfigured_deleted += 1,
+            Err(err) => {
+                error!("failed to delete dataset {dataset_id}: {err}; its chunks keep pinning the reclaim watermark")
+            }
         }
     }
 
@@ -139,5 +142,40 @@ fn startup_disk_recovery(db: &DBRef, unconfigured: &[DatasetId], disk_reclaim: b
         }
     }
 
-    debug!("startup disk recovery complete");
+    let bytes_after = table_sst_bytes(db);
+    // Only meaningful when both probes answered; a missing probe must not read as "freed 0".
+    let freed_bytes = bytes_before
+        .zip(bytes_after)
+        .map(|(before, after)| before.saturating_sub(after));
+
+    info!(
+        reclaim_enabled = disk_reclaim,
+        orphans_purged,
+        unconfigured_datasets = unconfigured.len(),
+        unconfigured_deleted,
+        table_sst_bytes_before = bytes_before,
+        table_sst_bytes_after = bytes_after,
+        freed_bytes,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "startup disk recovery complete"
+    );
+
+    if !disk_reclaim {
+        // FUTURE: ungate the orphan purge once the rollout measurement is done. It is safe
+        // without the unlink, and while gated an interrupted build leaks its data for good;
+        // it shares the flag only so `reclaim-measure` can still contrast the two watermarks.
+        info!("startup disk reclaim is off; enable with --startup-disk-reclaim");
+    }
+}
+
+/// Live SST bytes of `CF_TABLES`, straight from RocksDB metadata -- no SST reads. `None`
+/// when the property is unavailable, so a probe failure stays distinguishable from zero.
+fn table_sst_bytes(db: &DBRef) -> Option<u64> {
+    match db.get_property(CF_TABLES, "rocksdb.live-sst-files-size") {
+        Ok(value) => value.and_then(|v| v.parse().ok()),
+        Err(err) => {
+            warn!(error =? err, "failed to read live SST size");
+            None
+        }
+    }
 }

--- a/crates/hotblocks/src/dataset_controller/dataset_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/dataset_controller.rs
@@ -614,7 +614,7 @@ async fn compaction_loop(db: DBRef, dataset_id: DatasetId, mut enabled: tokio::s
 
             match result {
                 Ok(CompactionStatus::Ok(merged_chunks)) => {
-                    info!(
+                    debug!(
                         first_block = merged_chunks[0].first_block,
                         last_block = merged_chunks.last().unwrap().last_block,
                         size = merged_chunks.iter().map(|c| c.size).sum::<usize>(),

--- a/crates/hotblocks/src/dataset_controller/ingest_generic.rs
+++ b/crates/hotblocks/src/dataset_controller/ingest_generic.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 use sqd_data_core::{BlockChunkBuilder, ChunkProcessor, PreparedChunk};
 use sqd_data_source::{DataEvent, DataSource};
 use sqd_primitives::{Block, BlockNumber, BlockRef, DataMask, DisplayBlockRefOption};
-use tracing::{field::valuable, info};
+use tracing::{debug, field::valuable, info};
 
 use crate::dataset_controller::write_controller::Rollback;
 
@@ -230,7 +230,7 @@ where
         let last_block_time = DateTime::<Utc>::from_timestamp_millis(self.last_block_time.unwrap_or(0))
             .ok_or_else(|| anyhow!("block time is out of range"))?;
 
-        info!(
+        debug!(
             first_block = first_block,
             last_block = last_block,
             last_block_hash = %last_block_hash,

--- a/crates/hotblocks/src/dataset_controller/write_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/write_controller.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, ensure};
 use sqd_primitives::{BlockNumber, BlockRef};
 use sqd_storage::db::{Chunk as StorageChunk, Chunk, DatasetId};
-use tracing::{field::valuable, info, instrument, warn};
+use tracing::{debug, field::valuable, info, instrument, warn};
 
 use crate::types::{DBRef, DatasetKind};
 
@@ -324,14 +324,14 @@ impl WriteController {
         })?;
 
         if let Some(new_head) = update {
-            info!(
+            debug!(
                 block_number = new_head.number,
                 block_hash = new_head.hash,
                 "saved new finalized head"
             );
             self.finalized_head = Some(new_head);
         } else {
-            info!("finalized head was ignored")
+            debug!("finalized head was ignored")
         }
 
         Ok(())
@@ -370,7 +370,7 @@ impl WriteController {
             Ok(new_finalized_head)
         })?;
 
-        info!(finalized_head = valuable(&finalized_head), "saved new chunk");
+        debug!(finalized_head = valuable(&finalized_head), "saved new chunk");
 
         self.finalized_head = finalized_head;
         self.head = Some(get_chunk_head(&chunk));

--- a/crates/hotblocks/src/main.rs
+++ b/crates/hotblocks/src/main.rs
@@ -67,6 +67,10 @@ fn init_tracing() {
         tracing_subscriber::fmt()
             .with_env_filter(env_filter)
             .json()
+            // Event fields land at the top level instead of nested under `fields`, so a log
+            // sink queries `jsonPayload.freed_bytes` rather than `jsonPayload.fields.freed_bytes`.
+            // Matches what `sqd-archive` already does.
+            .flatten_event(true)
             .with_current_span(false)
             .init();
     }


### PR DESCRIPTION
We enabled `--startup-disk-reclaim` on mainnet and then could not see a single line about what it did. Two causes, both fixed here.

## Why nothing was visible

**INFO was 88% of log volume** — 311 lines/s on a mainnet pod, all of it per-request or per-block chatter. Measured over 10s on `network-hotblocks-mainnet/hotblocks-db-1`:

| rate | share | message | target |
|---|---|---|---|
| 183/s | 51.9% | `HTTP request processed` | `http_request` |
| 50/s | 14.2% | `received new chunk` | `ingest_generic` |
| 50/s | 14.1% | `saved new chunk` | `write_controller` |
| 18/s | 5.1% | `saved new finalized head` | `write_controller` |
| 10/s | 2.6% | `merged N chunks` | `dataset_controller` |

Two things fell out of that firehose:

- **kubelet** keeps `10Mi × 5` per container, so at ~9 MiB/min a pod retained **under a minute** of history. After a restart the startup lines were always already gone.
- **the GCP `_Default` sink** carries an exclusion (`portal-debug`) dropping `hotblocks-db` INFO **and** DEBUG outright. Of 1000 sampled entries in Cloud Logging: 507 WARNING, 1 ERROR, nothing else. The exclusion exists *because* of this firehose.

**And startup was silent by construction.** `reclaim_disk_space()` returns `Result<()>` and never counted anything; `purge_orphan_dirty_tables()` logged only on non-zero (`Ok(0) => {}`); the sole completion line was `debug!`. A successful boot printed exactly nothing.

## What changes

**Demote the six per-item events to DEBUG.** One-event-per-request / per-block by nature. Lifecycle events stay INFO — `fork received`, `resetting ingest position`, `dataset was cleared`, `retained blocks`, and the startup summary.

**Startup emits one fat event**, sizes from RocksDB's `live-sst-files-size` property (metadata only, no SST reads). The probe returns `Option`, so a failed read stays distinguishable from a genuine zero rather than reading as "freed 0".

**Flatten the JSON.** Fields were nested under `fields`, forcing `jsonPayload.fields.freed_bytes` in Cloud Logging — easy to get wrong, and I did get it wrong while hunting for these very lines. `sqd-archive` already sets `flatten_event(true)`; hotblocks now matches.

```json
{"timestamp":"2026-07-14T13:00:11.657730Z","level":"INFO",
 "message":"startup disk recovery complete",
 "reclaim_enabled":true,"orphans_purged":0,
 "unconfigured_datasets":0,"unconfigured_deleted":0,
 "table_sst_bytes_before":0,"table_sst_bytes_after":0,
 "freed_bytes":0,"elapsed_ms":0,
 "target":"sqd_hotblocks::data_service"}
```

## Effect, replayed on the real captured logs

Same 10s window from mainnet, re-scored under the new levels:

```
BEFORE:                 3522 lines / 10s = 352/s
AFTER (RUST_LOG=info):     5 lines / 10s = 0.5/s   (-99.9%)
```

Everything that survives:

```
WARN  data ingestion error, will disable the data source for 10000 ms   x3
INFO  fork received                                                     x1
INFO  resetting ingest position                                         x1
```

A reorg actually happened in that window. It used to be buried under 3500 lines; now it is one of five.

## Safety of the shape change

No GCP log-based metric reads hotblocks' payload — the `router-errors*` metrics are scoped to the `arrowsquid-router-archive` namespace. The `portal-debug` exclusion keys off severity, not fields.

## Test

Ran the real binary against a temp DB, both paths: with `--startup-disk-reclaim` (`reclaim_enabled: true`) and without (`false`, plus the existing "reclaim is off" hint). `cargo check` and `clippy` clean on the touched files; `cargo +nightly fmt` applied.

## Follow-ups (not in this PR)

- Narrow the GCP `portal-debug` exclusion. With the firehose gone, blanket-dropping `hotblocks-db` INFO throws away the very event this PR adds. Scope it to `jsonPayload.target="http_request"` instead of all INFO — **after** this merges, or the current 311/s hits Cloud Logging.
- Mainnet still runs `RUST_LOG=info,sqd_hotblocks=debug`; dropping `sqd_hotblocks=debug` restores real `kubectl logs` depth.
- `hotblocks-retain` and `bds` still nest their JSON — same one-line fix if we want the whole fleet consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)