### PR TITLE
feat(hotblocks): expose RocksDB stall metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4914,6 +4914,7 @@ dependencies = [
  "sqd-primitives",
  "sqd-query",
  "sqd-storage",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "tower-http",

--- a/crates/hotblocks/Cargo.toml
+++ b/crates/hotblocks/Cargo.toml
@@ -37,6 +37,7 @@ url = { workspace = true, features = ["serde"] }
 [dev-dependencies]
 anyhow = { workspace = true }
 sqd-hotblocks-harness = { path = "../hotblocks-harness" }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [lints]

--- a/crates/hotblocks/spec/audit-2026-07-12.md
+++ b/crates/hotblocks/spec/audit-2026-07-12.md
@@ -102,7 +102,7 @@ Consequence: restart of an Api dataset reverts it to `RetentionStrategy::None`; 
 **Where:** `write_controller.rs:107-137` — hints are matched only against chunk **last** blocks; a hint matching a mid-chunk stored block is skipped and the rollback lands on the next lower chunk boundary (consistently, `insert_fork` can only splice at chunk boundaries). Content-wise benign (the replacement re-serves identical blocks), but it deviates from WP-6's MUST-algorithm, inflates reorg depth observables, re-ingests more than needed, and the reference model will diverge on rollback positions. Spec should either allow boundary-granular rollback (≤ one chunk deeper than necessary) or the impl must refine within-chunk matching.
 
 ### N18 (P3) — OB-1 incomplete: commit version not exported
-**Where:** `metrics.rs` exports `first/last/last_finalized/last_block_timestamp` per dataset; `DatasetLabel.version` exists but is not exposed, and the retention policy in force isn't either. OB-1 lists both. (Also: OB-3 stall/pressure gauges are on PR #83, not this branch — the §5 matrix row "stall gauges … exist" is ahead of reality; `get_global_tx_restarts` (HZ-11) is warn-log only.)
+**Where:** `metrics.rs` exports `first/last/last_finalized/last_block_timestamp` per dataset; `DatasetLabel.version` exists but is not exposed, and the retention policy in force isn't either. OB-1 lists both. The RocksDB portion of OB-3 is now exposed (`write_stopped`, delayed write rate, and per-CF flush/compaction/backlog gauges), but pipeline queue depths and maintenance retry counters remain absent; `get_global_tx_restarts` (HZ-11) is still warn-log only.
 
 ---
 

--- a/crates/hotblocks/src/cli.rs
+++ b/crates/hotblocks/src/cli.rs
@@ -1,16 +1,18 @@
 use std::{
     collections::{BTreeSet, HashSet},
-    sync::Arc
+    sync::Arc,
+    time::Instant
 };
 
 use anyhow::Context;
 use clap::Parser;
 use sqd_storage::db::{DatabaseSettings, DatasetId};
+use tracing::info;
 
 use crate::{
     data_service::{DataService, DataServiceRef},
     dataset_config::{DatasetConfig, RetentionConfig},
-    metrics::DatasetMetricsCollector,
+    metrics::{DatasetMetricsCollector, RocksDbCollector},
     query::{QueryService, QueryServiceRef},
     types::DBRef
 };
@@ -115,16 +117,23 @@ impl CLI {
             settings = settings.with_max_background_jobs(jobs);
         }
 
+        let db_open_started = Instant::now();
+        info!("opening RocksDB");
         let db = settings
             .open(&self.database_dir)
             .map(Arc::new)
             .context("failed to open rocksdb database")?;
+        info!(
+            elapsed_ms = db_open_started.elapsed().as_millis() as u64,
+            "RocksDB opened"
+        );
 
         let mut metrics_registry = crate::metrics::build_metrics_registry();
         metrics_registry.register_collector(Box::new(DatasetMetricsCollector {
             db: db.clone(),
             datasets: datasets.keys().copied().collect()
         }));
+        metrics_registry.register_collector(Box::new(RocksDbCollector { db: db.clone() }));
 
         let api_controlled_datasets = datasets
             .iter()

--- a/crates/hotblocks/src/data_service.rs
+++ b/crates/hotblocks/src/data_service.rs
@@ -45,6 +45,10 @@ impl DataService {
             }
         }
 
+        let configured_datasets = datasets.len();
+        let controller_init_started = Instant::now();
+        info!(configured_datasets, "dataset controller initialization started");
+
         let mut controllers = futures::stream::iter(datasets.into_iter())
             .map(|(dataset_id, cfg)| {
                 let db = db.clone();
@@ -81,6 +85,13 @@ impl DataService {
             datasets.insert(ctl.dataset_id(), ctl);
         }
 
+        info!(
+            configured_datasets,
+            datasets_ready = datasets.len(),
+            elapsed_ms = controller_init_started.elapsed().as_millis() as u64,
+            "dataset controller initialization complete"
+        );
+
         Ok(Self { datasets })
     }
 
@@ -113,6 +124,13 @@ fn startup_disk_recovery(db: &DBRef, unconfigured: &[DatasetId], disk_reclaim: b
     let started = Instant::now();
     let bytes_before = table_sst_bytes(db);
 
+    info!(
+        reclaim_enabled = disk_reclaim,
+        unconfigured_datasets = unconfigured.len(),
+        table_sst_bytes_before = bytes_before,
+        "startup disk recovery started"
+    );
+
     let mut orphans_purged = 0usize;
     let mut unconfigured_deleted = 0usize;
 
@@ -131,7 +149,11 @@ fn startup_disk_recovery(db: &DBRef, unconfigured: &[DatasetId], disk_reclaim: b
         match db.delete_dataset(*dataset_id) {
             Ok(()) => unconfigured_deleted += 1,
             Err(err) => {
-                error!("failed to delete dataset {dataset_id}: {err}; its chunks keep pinning the reclaim watermark")
+                error!(
+                    dataset_id = %dataset_id,
+                    error =? err,
+                    "failed to delete dataset; its chunks keep pinning the reclaim watermark"
+                )
             }
         }
     }

--- a/crates/hotblocks/src/metrics.rs
+++ b/crates/hotblocks/src/metrics.rs
@@ -12,7 +12,7 @@ use prometheus_client::{
     },
     registry::Registry
 };
-use sqd_storage::db::{DatasetId, ReadSnapshot};
+use sqd_storage::db::{CF_CHUNKS, CF_DATASETS, CF_DELETED_TABLES, CF_DIRTY_TABLES, CF_TABLES, DatasetId, ReadSnapshot};
 use tracing::error;
 
 use crate::{query::QueryExecutorCollector, types::DBRef};
@@ -168,6 +168,188 @@ fn collect_dataset_metrics(
     Ok(())
 }
 
+/// RocksDB write-pressure and maintenance gauges collected from intrinsic properties.
+///
+/// Property reads happen only during a Prometheus scrape and do not require RocksDB's
+/// optional statistics collection. Labels are bounded by the five configured column
+/// families.
+#[derive(Debug)]
+pub struct RocksDbCollector {
+    pub db: DBRef
+}
+
+#[derive(Copy, Clone)]
+enum PropertyMetricType {
+    Gauge,
+    Counter
+}
+
+impl PropertyMetricType {
+    const fn metric_type(self) -> MetricType {
+        match self {
+            Self::Gauge => MetricType::Gauge,
+            Self::Counter => MetricType::Counter
+        }
+    }
+}
+
+struct RocksDbPropertyMetric {
+    metric: &'static str,
+    help: &'static str,
+    property: &'static str,
+    metric_type: PropertyMetricType
+}
+
+// DB-wide properties are exposed through any existing column-family handle.
+const ROCKSDB_DB_WIDE: &[RocksDbPropertyMetric] = &[
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_write_stopped",
+        help: "1 while RocksDB has hard-stopped all writes",
+        property: "rocksdb.is-write-stopped",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_actual_delayed_write_rate_bytes_per_second",
+        help: "Current RocksDB soft-stall write rate in bytes per second; 0 when writes are not delayed",
+        property: "rocksdb.actual-delayed-write-rate",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_running_compactions",
+        help: "Number of RocksDB compactions currently running",
+        property: "rocksdb.num-running-compactions",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_running_flushes",
+        help: "Number of RocksDB memtable flushes currently running",
+        property: "rocksdb.num-running-flushes",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_snapshots",
+        help: "Number of unreleased RocksDB snapshots",
+        property: "rocksdb.num-snapshots",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_oldest_snapshot_time_seconds",
+        help: "Unix timestamp of the oldest unreleased RocksDB snapshot; 0 when none exist",
+        property: "rocksdb.oldest-snapshot-time",
+        metric_type: PropertyMetricType::Gauge
+    }
+];
+
+const ROCKSDB_PER_CF: &[RocksDbPropertyMetric] = &[
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_files_at_level0",
+        help: "Number of RocksDB SST files at level 0",
+        property: "rocksdb.num-files-at-level0",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_pending_compaction_bytes",
+        help: "Estimated bytes RocksDB must compact to bring levels under their targets",
+        property: "rocksdb.estimate-pending-compaction-bytes",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_compaction_pending",
+        help: "1 when RocksDB has determined that a column family needs compaction",
+        property: "rocksdb.compaction-pending",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_immutable_memtables",
+        help: "Number of immutable RocksDB memtables waiting to be flushed",
+        property: "rocksdb.num-immutable-mem-table",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_memtable_flush_pending",
+        help: "1 while a RocksDB memtable flush is pending",
+        property: "rocksdb.mem-table-flush-pending",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_memtable_bytes",
+        help: "Approximate bytes in active and unflushed immutable RocksDB memtables",
+        property: "rocksdb.cur-size-all-mem-tables",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_estimated_keys",
+        help: "Estimated live keys in a RocksDB column family, including memtables and SST files",
+        property: "rocksdb.estimate-num-keys",
+        metric_type: PropertyMetricType::Gauge
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_background_errors",
+        help: "Accumulated RocksDB background flush and compaction errors",
+        property: "rocksdb.background-errors",
+        metric_type: PropertyMetricType::Counter
+    },
+    RocksDbPropertyMetric {
+        metric: "hotblocks_rocksdb_live_sst_files_bytes",
+        help: "Bytes in RocksDB SST files belonging to the current LSM version",
+        property: "rocksdb.live-sst-files-size",
+        metric_type: PropertyMetricType::Gauge
+    }
+];
+
+const ROCKSDB_COLUMN_FAMILIES: &[&str] = &[CF_DATASETS, CF_CHUNKS, CF_TABLES, CF_DIRTY_TABLES, CF_DELETED_TABLES];
+
+#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq, EncodeLabelSet)]
+struct ColumnFamilyLabel {
+    cf: &'static str
+}
+
+impl Collector for RocksDbCollector {
+    fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+        match collect_rocksdb_metrics(&mut encoder, &self.db) {
+            Ok(()) => Ok(()),
+            Err(err) => match err.downcast::<std::fmt::Error>() {
+                Ok(err) => Err(err),
+                Err(err) => {
+                    error!(error =? err, "failed to collect RocksDB metrics");
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+fn collect_rocksdb_metrics(encoder: &mut DescriptorEncoder, db: &DBRef) -> anyhow::Result<()> {
+    for spec in ROCKSDB_DB_WIDE {
+        let Some(value) = db.get_int_property(CF_TABLES, spec.property)? else {
+            continue;
+        };
+
+        encoder
+            .encode_descriptor(spec.metric, spec.help, None, spec.metric_type.metric_type())?
+            .encode_gauge(&value)?;
+    }
+
+    for spec in ROCKSDB_PER_CF {
+        let mut metric = encoder.encode_descriptor(spec.metric, spec.help, None, spec.metric_type.metric_type())?;
+
+        for &cf in ROCKSDB_COLUMN_FAMILIES {
+            let Some(value) = db.get_int_property(cf, spec.property)? else {
+                continue;
+            };
+
+            let label = ColumnFamilyLabel { cf };
+            let mut sample = metric.encode_family(&label)?;
+            match spec.metric_type {
+                PropertyMetricType::Gauge => sample.encode_gauge(&value)?,
+                PropertyMetricType::Counter => sample.encode_counter::<ColumnFamilyLabel, u64, u64>(&value, None)?
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub fn build_metrics_registry() -> Registry {
     let mut top_registry = Registry::default();
     let registry = top_registry.sub_registry_with_prefix("hotblocks");
@@ -241,5 +423,215 @@ impl Collector for QueryExecutorCollector {
             )?
             .encode_gauge(&active_queries)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering}
+        },
+        thread,
+        time::{Duration, Instant}
+    };
+
+    use sqd_storage::db::{Chunk, DatabaseSettings, DatasetId, DatasetKind};
+
+    use super::*;
+
+    #[test]
+    fn rocksdb_collector_exposes_global_and_per_cf_properties() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(DatabaseSettings::default().open(dir.path()).unwrap());
+        let mut registry = Registry::default();
+        registry.register_collector(Box::new(RocksDbCollector { db }));
+
+        let mut output = String::new();
+        prometheus_client::encoding::text::encode(&mut output, &registry).unwrap();
+
+        for spec in ROCKSDB_DB_WIDE {
+            assert_metric_exposed(&output, spec.metric);
+        }
+
+        for spec in ROCKSDB_PER_CF {
+            assert_metric_exposed(&output, spec.metric);
+            for cf in ROCKSDB_COLUMN_FAMILIES {
+                let metric = match spec.metric_type {
+                    PropertyMetricType::Gauge => spec.metric.to_owned(),
+                    PropertyMetricType::Counter => format!("{}_total", spec.metric)
+                };
+                assert!(
+                    output
+                        .lines()
+                        .any(|line| { line.starts_with(&metric) && line.contains(&format!("cf=\"{cf}\"")) }),
+                    "missing {metric} for column family {cf}:\n{output}"
+                );
+            }
+        }
+    }
+
+    fn assert_metric_exposed(output: &str, metric: &str) {
+        assert!(
+            output
+                .lines()
+                .any(|line| line.starts_with(metric) && !line.starts_with('#')),
+            "missing metric {metric}:\n{output}"
+        );
+    }
+
+    /// Reproducible manual check that continuous Prometheus collection does not create
+    /// meaningful contention on RocksDB reads or writes. The scraper intentionally runs
+    /// without the production scrape interval, making this a much harsher workload.
+    #[test]
+    #[ignore = "manual RocksDB metrics overhead benchmark"]
+    fn benchmark_rocksdb_metrics_overhead() {
+        const PREPARE_WRITES: u64 = 500;
+        const MEASURED_WRITES: u64 = 2_000;
+        const MEASURED_READS: usize = 20_000;
+        const MEASURED_SCRAPES: usize = 1_000;
+
+        let baseline_dir = tempfile::tempdir().unwrap();
+        let baseline_db = Arc::new(DatabaseSettings::default().open(baseline_dir.path()).unwrap());
+        let stressed_dir = tempfile::tempdir().unwrap();
+        let stressed_db = Arc::new(DatabaseSettings::default().open(stressed_dir.path()).unwrap());
+        let dataset_id = DatasetId::from_str("metrics-benchmark");
+        let dataset_kind = DatasetKind::from_str("benchmark");
+
+        for db in [&baseline_db, &stressed_db] {
+            db.create_dataset(dataset_id, dataset_kind).unwrap();
+            write_chunks(db, dataset_id, 0, PREPARE_WRITES);
+        }
+
+        let scrape_latencies = measure_scrapes(Arc::clone(&baseline_db), MEASURED_SCRAPES);
+        let baseline_writes = measure_writes(
+            &baseline_db,
+            dataset_id,
+            PREPARE_WRITES,
+            PREPARE_WRITES + MEASURED_WRITES
+        );
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let scraper = spawn_continuous_scraper(Arc::clone(&stressed_db), Arc::clone(&stop));
+        let stressed_writes = measure_writes(
+            &stressed_db,
+            dataset_id,
+            PREPARE_WRITES,
+            PREPARE_WRITES + MEASURED_WRITES
+        );
+        stop.store(true, Ordering::Relaxed);
+        let write_scrapes = scraper.join().unwrap();
+
+        let baseline_reads = measure_reads(&baseline_db, dataset_id, MEASURED_READS);
+        stop.store(false, Ordering::Relaxed);
+        let scraper = spawn_continuous_scraper(Arc::clone(&stressed_db), Arc::clone(&stop));
+        let stressed_reads = measure_reads(&stressed_db, dataset_id, MEASURED_READS);
+        stop.store(true, Ordering::Relaxed);
+        let read_scrapes = scraper.join().unwrap();
+
+        eprintln!("full scrape:        {}", summarize(scrape_latencies));
+        eprintln!("writes baseline:    {}", summarize(baseline_writes));
+        eprintln!(
+            "writes + scraping:  {} ({write_scrapes} concurrent scrapes)",
+            summarize(stressed_writes)
+        );
+        eprintln!("reads baseline:     {}", summarize(baseline_reads));
+        eprintln!(
+            "reads + scraping:   {} ({read_scrapes} concurrent scrapes)",
+            summarize(stressed_reads)
+        );
+    }
+
+    fn write_chunks(db: &DBRef, dataset_id: DatasetId, from: u64, to: u64) {
+        for block in from..to {
+            db.insert_chunk(dataset_id, &chunk(block)).unwrap();
+        }
+    }
+
+    fn measure_writes(db: &DBRef, dataset_id: DatasetId, from: u64, to: u64) -> Vec<Duration> {
+        (from..to)
+            .map(|block| {
+                let started = Instant::now();
+                db.insert_chunk(dataset_id, &chunk(block)).unwrap();
+                started.elapsed()
+            })
+            .collect()
+    }
+
+    fn measure_reads(db: &DBRef, dataset_id: DatasetId, count: usize) -> Vec<Duration> {
+        (0..count)
+            .map(|_| {
+                let started = Instant::now();
+                let snapshot = db.snapshot();
+                assert!(snapshot.get_last_chunk(dataset_id).unwrap().is_some());
+                started.elapsed()
+            })
+            .collect()
+    }
+
+    fn measure_scrapes(db: DBRef, count: usize) -> Vec<Duration> {
+        let mut registry = Registry::default();
+        registry.register_collector(Box::new(RocksDbCollector { db }));
+        let mut output = String::with_capacity(16 * 1024);
+
+        (0..count)
+            .map(|_| {
+                output.clear();
+                let started = Instant::now();
+                prometheus_client::encoding::text::encode(&mut output, &registry).unwrap();
+                started.elapsed()
+            })
+            .collect()
+    }
+
+    fn spawn_continuous_scraper(db: DBRef, stop: Arc<AtomicBool>) -> thread::JoinHandle<u64> {
+        thread::spawn(move || {
+            let mut registry = Registry::default();
+            registry.register_collector(Box::new(RocksDbCollector { db }));
+            let mut output = String::with_capacity(16 * 1024);
+            let mut scrapes = 0;
+
+            while !stop.load(Ordering::Relaxed) {
+                output.clear();
+                prometheus_client::encoding::text::encode(&mut output, &registry).unwrap();
+                scrapes += 1;
+            }
+
+            scrapes
+        })
+    }
+
+    fn chunk(block: u64) -> Chunk {
+        Chunk::V0 {
+            first_block: block,
+            last_block: block,
+            last_block_hash: format!("hash-{block}"),
+            parent_block_hash: if block == 0 {
+                "genesis".to_owned()
+            } else {
+                format!("hash-{}", block - 1)
+            },
+            tables: Default::default()
+        }
+    }
+
+    fn summarize(mut samples: Vec<Duration>) -> String {
+        samples.sort_unstable();
+        let total: Duration = samples.iter().sum();
+        format!(
+            "n={}, total={:.3}s, p50={:?}, p95={:?}, p99={:?}, max={:?}",
+            samples.len(),
+            total.as_secs_f64(),
+            percentile(&samples, 50),
+            percentile(&samples, 95),
+            percentile(&samples, 99),
+            samples.last().copied().unwrap_or_default()
+        )
+    }
+
+    fn percentile(samples: &[Duration], percentile: usize) -> Duration {
+        let index = samples.len().saturating_sub(1) * percentile / 100;
+        samples[index]
     }
 }

--- a/crates/storage/src/db/db.rs
+++ b/crates/storage/src/db/db.rs
@@ -396,6 +396,18 @@ impl Database {
         let val = self.db.property_value_cf(cf_handle, name)?;
         Ok(val)
     }
+
+    /// Read an integer RocksDB property for a column family.
+    ///
+    /// Returns `None` when either the column family or property does not exist. Intrinsic
+    /// properties are available even when RocksDB statistics collection is disabled.
+    pub fn get_int_property(&self, cf: &str, name: &str) -> anyhow::Result<Option<u64>> {
+        let Some(cf_handle) = self.db.cf_handle(cf) else {
+            return Ok(None);
+        };
+        let val = self.db.property_int_value_cf(cf_handle, name)?;
+        Ok(val)
+    }
 }
 
 impl std::fmt::Debug for Database {

--- a/crates/storage/tests/rocksdb_properties.rs
+++ b/crates/storage/tests/rocksdb_properties.rs
@@ -1,0 +1,62 @@
+//! Integer properties back the `hotblocks_rocksdb_*` collector. They must stay available
+//! without `enable_statistics()` because production disables RocksDB statistics by default.
+
+use sqd_storage::db::{DatabaseSettings, CF_CHUNKS, CF_DATASETS, CF_DELETED_TABLES, CF_DIRTY_TABLES, CF_TABLES};
+
+const DB_WIDE_PROPERTIES: &[&str] = &[
+    "rocksdb.is-write-stopped",
+    "rocksdb.actual-delayed-write-rate",
+    "rocksdb.num-running-compactions",
+    "rocksdb.num-running-flushes",
+    "rocksdb.num-snapshots",
+    "rocksdb.oldest-snapshot-time"
+];
+
+const PER_CF_PROPERTIES: &[&str] = &[
+    "rocksdb.num-files-at-level0",
+    "rocksdb.estimate-pending-compaction-bytes",
+    "rocksdb.compaction-pending",
+    "rocksdb.num-immutable-mem-table",
+    "rocksdb.mem-table-flush-pending",
+    "rocksdb.cur-size-all-mem-tables",
+    "rocksdb.estimate-num-keys",
+    "rocksdb.background-errors",
+    "rocksdb.live-sst-files-size"
+];
+
+const COLUMN_FAMILIES: &[&str] = &[CF_DATASETS, CF_CHUNKS, CF_TABLES, CF_DIRTY_TABLES, CF_DELETED_TABLES];
+
+#[test]
+fn collector_properties_are_available_without_statistics() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = DatabaseSettings::default().open(dir.path()).unwrap();
+
+    for property in DB_WIDE_PROPERTIES {
+        assert!(
+            db.get_int_property(CF_TABLES, property).unwrap().is_some(),
+            "DB-wide property {property} returned None"
+        );
+    }
+
+    for cf in COLUMN_FAMILIES {
+        for property in PER_CF_PROPERTIES {
+            assert!(
+                db.get_int_property(cf, property).unwrap().is_some(),
+                "property {property} on column family {cf} returned None"
+            );
+        }
+    }
+
+    assert_eq!(
+        db.get_int_property(CF_TABLES, "rocksdb.is-write-stopped").unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        db.get_int_property("UNKNOWN", "rocksdb.is-write-stopped").unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_int_property(CF_TABLES, "rocksdb.unknown-property").unwrap(),
+        None
+    );
+}


### PR DESCRIPTION
## Summary

- expose bounded RocksDB write-stall, compaction, flush, memtable, snapshot, and background-error metrics
- add low-volume startup phase logs around DB open, dataset controller initialization, and disk recovery
- verify selected properties remain available with RocksDB statistics disabled
- include an ignored reproducible benchmark for scrape overhead on reads and writes

## Why

When all datasets stop advancing together, these signals distinguish a RocksDB hard or soft write stall from blocking-pool or upstream pipeline starvation. Per-column-family backlog metrics make the responsible LSM area visible without enabling expensive RocksDB statistics.

## Performance

The collector reads fixed-cardinality in-memory integer properties only during Prometheus scrapes. Expensive properties that iterate SST files or versions are excluded.

Release benchmark under continuous scraping, much harsher than a production scrape interval:

- full scrape p50: 11.166 us
- write p50: 9.125 us baseline, 8.667 us with scraping
- read p50: 1.166 us baseline, 1.250 us with scraping

## Verification

- cargo test -p sqd-hotblocks
- cargo test -p sqd-storage
- cargo +nightly fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D clippy::correctness
- git diff --check