### PR TITLE
ci: run tests on master, so PRs have a cache to restore

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,8 +2,9 @@ name: Rust Tests
 
 on:
   push:
+    # Must be the default branch: a PR can only restore caches from its own ref or from it.
     branches:
-      - main
+      - master
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:


### PR DESCRIPTION
The push trigger listed `main`. This repo's default branch is **`master`**, so it never fired — `Rust Tests` has **zero runs on the default branch, ever**.

That is why every PR builds cold.

## Why a typo costs 35 minutes per PR

Actions caches are scoped to the ref that wrote them, and a run may only restore caches from **its own ref** or from the **default branch**. With nothing ever running on master, no cache was ever scoped to `refs/heads/master`. So each PR warmed only `refs/pull/N/merge` — a scope no *other* PR is allowed to read:

| cache key | ref | size |
|---|---|---|
| `v0-rust-rust-ci-test-…` | `refs/pull/89/merge` | 1348 MiB |
| `v0-rust-clippy-…` | `refs/pull/87/merge` | 752 MiB |
| `v0-rust-test-…` | `refs/pull/86/merge` | 1332 MiB |
| `v0-rust-test-…` | `refs/pull/84/merge` | 1332 MiB |

Every entry sits on a pull ref. Not one on master. Each PR paid the full cold build — **~35 min for `test`**, ~8 min for clippy — then handed its warm cache to a ref that dies with the PR.

Running on master populates the one scope every PR is allowed to read. The first post-merge run is still cold; after that, PRs restore from master.

## Push already flows through the rest of the workflow

Checked, not assumed:

- job `if` admits `event_name == 'push'`
- `runs-on` resolves to self-hosted (the fork check only applies to `pull_request`)
- `cancel-in-progress` is `false` for push, so back-to-back merges do not cancel each other

## Related

Complements #89, which gave `clippy` and `test` separate cache keys. That fix was real but its effect was invisible: within one pull ref, clippy's check-only target dir was poisoning test's restore, but no cache survived the PR boundary anyway. Both are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)