### PR TITLE
add transactionTraces relation to EVM trace filter

### DIFF
--- a/crates/query/fixtures/ethereum/queries/transaction_traces_for_traces/query.json
+++ b/crates/query/fixtures/ethereum/queries/transaction_traces_for_traces/query.json
@@ -1,0 +1,28 @@
+{
+  "type": "evm",
+  "fromBlock": 17881391,
+  "toBlock": 17881391,
+  "traces": [
+    {
+      "callSighash": ["0xe21fd0e9"],
+      "transactionTraces": true
+    }
+  ],
+  "fields": {
+    "block": {
+      "number": true,
+      "hash": true
+    },
+    "trace": {
+      "transactionIndex": true,
+      "traceAddress": true,
+      "type": true,
+      "callFrom": true,
+      "callTo": true,
+      "callValue": true,
+      "callGas": true,
+      "callCallType": true,
+      "callSighash": true
+    }
+  }
+}

--- a/crates/query/fixtures/ethereum/queries/transaction_traces_for_traces/result.json
+++ b/crates/query/fixtures/ethereum/queries/transaction_traces_for_traces/result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:373bda1569bef60f9957a36b24cce2736a5dd8ca6f77b2c9f4a52f0dca6a045d
+size 8914

--- a/crates/query/src/query/eth.rs
+++ b/crates/query/src/query/eth.rs
@@ -584,6 +584,7 @@ request! {
         pub reward_value_non_zero: bool,
         pub transaction: bool,
         pub transaction_logs: bool,
+        pub transaction_traces: bool,
         pub subtraces: bool,
         pub parents: bool,
     }
@@ -632,6 +633,13 @@ impl TraceRequest {
         if self.transaction_logs {
             scan.join(
                 "logs",
+                vec!["block_number", "transaction_index"],
+                vec!["block_number", "transaction_index"]
+            );
+        }
+        if self.transaction_traces {
+            scan.join(
+                "traces",
                 vec!["block_number", "transaction_index"],
                 vec!["block_number", "transaction_index"]
             );


### PR DESCRIPTION
This pr is introducing more efficient trace filtering to support the Ponder native RPC flow. The current approach forces roughly 100x overfetch.