### PR TITLE
feat(hotblocks): add transaction hash index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,6 +5026,7 @@ dependencies = [
  "arrow",
  "arrow-buffer",
  "borsh",
+ "criterion",
  "parking_lot",
  "proptest",
  "rand 0.9.0",

--- a/crates/hotblocks-harness/src/chain/evm.rs
+++ b/crates/hotblocks-harness/src/chain/evm.rs
@@ -30,7 +30,7 @@ fn log_count(b: &Block) -> u32 {
 }
 
 /// Distinct from any block hash: block numbers never reach this domain.
-fn tx_hash(b: &Block, index: u32) -> String {
+pub fn transaction_hash(b: &Block, index: u32) -> String {
     block_hash(
         b.number.wrapping_mul(1_000_003).wrapping_add(u64::from(index)),
         b.fork_id
@@ -72,7 +72,7 @@ impl Evm {
     fn projected_tx(b: &Block, index: u32) -> Value {
         json!({
             "transactionIndex": index,
-            "hash": tx_hash(b, index),
+            "hash": transaction_hash(b, index),
             "from": SENDER,
             // A plain number here, unlike every other numeric field of a transaction.
             "nonce": b.number
@@ -107,7 +107,7 @@ impl Evm {
         let mut log = Self::projected_log(b, index);
         log.as_object_mut()
             .expect("log is an object")
-            .insert("transactionHash".into(), json!(tx_hash(b, 0)));
+            .insert("transactionHash".into(), json!(transaction_hash(b, 0)));
         log
     }
 }

--- a/crates/hotblocks-harness/src/compare.rs
+++ b/crates/hotblocks-harness/src/compare.rs
@@ -15,7 +15,7 @@ use crate::{
     chain::Chain,
     driver::{Client, Status},
     model::Model,
-    types::{BlockNumber, BlockRef}
+    types::{Block, BlockNumber, BlockRef, TransactionRef}
 };
 
 #[derive(Clone, Debug)]
@@ -113,6 +113,64 @@ pub async fn assert_hash_index_conforms(client: &Client, model: &Model) -> Resul
     } else {
         bail!(
             "the block-hash index diverged from the model:\n  - {}",
+            errs.join("\n  - ")
+        )
+    }
+}
+
+/// Materializes the transaction positions present in the chain oracle's
+/// projected block. Keeping this derivation at the binding boundary means the
+/// reference model remains kind-agnostic.
+pub fn expected_transactions(chain: &dyn Chain, block: &Block) -> Result<Vec<TransactionRef>> {
+    let emission = chain.expected_emission(block);
+    let Some(transactions) = emission.get("transactions") else {
+        return Ok(Vec::new());
+    };
+    let transactions = transactions
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("expected transactions projection is not an array"))?;
+
+    transactions
+        .iter()
+        .map(|transaction| {
+            let transaction_index = transaction
+                .get("transactionIndex")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| anyhow::anyhow!("projected transaction has no numeric transactionIndex"))?
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("projected transactionIndex does not fit u32"))?;
+            let hash = transaction
+                .get("hash")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("projected transaction has no string hash"))?;
+            Ok(TransactionRef::new(block.number, transaction_index, hash))
+        })
+        .collect()
+}
+
+/// Every transaction on the canonical model branch resolves to its exact
+/// block/index position. This completeness assertion is valid only in the
+/// harness's fresh-store, always-enabled EVM scenarios (spec 12 §2).
+pub async fn assert_transaction_hash_index_conforms(client: &Client, model: &Model, chain: &dyn Chain) -> Result<()> {
+    let mut errs = Vec::new();
+    for block in &model.seg {
+        for transaction in expected_transactions(chain, block)? {
+            let expected = Some(transaction.clone());
+            let observed = client.transaction_by_hash(&transaction.hash).await?;
+            if observed != expected {
+                errs.push(format!(
+                    "hash {}: expected {expected:?}, got {observed:?}",
+                    transaction.hash
+                ));
+            }
+        }
+    }
+
+    if errs.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "the transaction-hash index diverged from the model:\n  - {}",
             errs.join("\n  - ")
         )
     }

--- a/crates/hotblocks-harness/src/driver.rs
+++ b/crates/hotblocks-harness/src/driver.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 use crate::{
     chain::Chain,
-    types::{BlockNumber, BlockRef}
+    types::{BlockNumber, BlockRef, TransactionRef}
 };
 
 /// One block as the service emitted it (IB-4: one JSON object per record).
@@ -163,6 +163,51 @@ impl Client {
                 res.text().await.unwrap_or_default()
             )
         }
+    }
+
+    /// Returns the raw binding status for malformed block-hash input checks.
+    pub async fn block_by_hash_status(&self, hash: &str) -> Result<u16> {
+        Ok(self
+            .http
+            .get(self.url(&format!("hashes/{hash}/block")))
+            .send()
+            .await?
+            .status()
+            .as_u16())
+    }
+
+    /// Resolves a transaction hash through the public hash-index endpoint. A
+    /// missing hash is a normal `None`; all other failures violate the binding.
+    pub async fn transaction_by_hash(&self, hash: &str) -> Result<Option<TransactionRef>> {
+        let res = self
+            .http
+            .get(self.url(&format!("hashes/{hash}/transaction")))
+            .send()
+            .await?;
+        let status = res.status();
+
+        match status.as_u16() {
+            200 => Ok(Some(
+                res.json().await.context("malformed transaction-hash lookup payload")?
+            )),
+            404 => Ok(None),
+            _ => bail!(
+                "transaction-hash lookup failed with {}: {}",
+                status.as_u16(),
+                res.text().await.unwrap_or_default()
+            )
+        }
+    }
+
+    /// Returns the raw binding status for malformed-input conformance checks.
+    pub async fn transaction_by_hash_status(&self, hash: &str) -> Result<u16> {
+        Ok(self
+            .http
+            .get(self.url(&format!("hashes/{hash}/transaction")))
+            .send()
+            .await?
+            .status()
+            .as_u16())
     }
 
     /// SET-RETENTION (DEF-9). Returns the status code: `403` unless the dataset is API-controlled.

--- a/crates/hotblocks-harness/src/harness.rs
+++ b/crates/hotblocks-harness/src/harness.rs
@@ -170,6 +170,12 @@ impl Harness {
         compare::assert_hash_index_conforms(&self.client, &self.model).await
     }
 
+    /// Diff the opt-in transaction-hash endpoint against every canonical
+    /// transaction in the model's projected chain.
+    pub async fn assert_transaction_hash_index_conforms(&self) -> Result<()> {
+        compare::assert_transaction_hash_index_conforms(&self.client, &self.model, &*self.chain).await
+    }
+
     /// An anchored follower positioned at the bottom of the window (04 §7).
     pub fn follower(&self) -> Follower {
         Follower::new(

--- a/crates/hotblocks-harness/src/types.rs
+++ b/crates/hotblocks-harness/src/types.rs
@@ -11,6 +11,25 @@ pub struct BlockRef {
     pub hash: String
 }
 
+/// DEF-17 transaction-hash lookup result.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionRef {
+    pub block_number: BlockNumber,
+    pub transaction_index: u32,
+    pub hash: String
+}
+
+impl TransactionRef {
+    pub fn new(block_number: BlockNumber, transaction_index: u32, hash: impl Into<String>) -> Self {
+        Self {
+            block_number,
+            transaction_index,
+            hash: hash.into()
+        }
+    }
+}
+
 impl BlockRef {
     pub fn new(number: BlockNumber, hash: impl Into<String>) -> Self {
         Self {

--- a/crates/hotblocks/Cargo.toml
+++ b/crates/hotblocks/Cargo.toml
@@ -24,7 +24,7 @@ sqd-data-core = { path = "../data-core" }
 sqd-data-source = { path = "../data-source" }
 sqd-dataset = { path = "../dataset" }
 sqd-polars = { path = "../polars" }
-sqd-primitives = { path = "../primitives", features = ["valuable"] }
+sqd-primitives = { path = "../primitives", features = ["serde", "valuable"] }
 sqd-query = { path = "../query", features = ["storage"] }
 sqd-storage = { path = "../storage" }
 tikv-jemallocator = "0.6.0"

--- a/crates/hotblocks/spec/09-retention-and-space.md
+++ b/crates/hotblocks/spec/09-retention-and-space.md
@@ -92,6 +92,23 @@ Requirements:
   two are independently enabled (`P-BLOCK-INDEX`, `P-TX-INDEX`) rather than sharing a
   switch.
 
+  A controlled Snappy/LZ4 sizing run on 2026-07-15 used identical random-looking 32-byte
+  hashes, production key/value encodings and Bloom filters. Each sample was flushed and fully
+  compacted; the figures are live SST bytes for the named index only, excluding WAL,
+  memtables and table data.
+
+  | Entries/index | Block, Snappy | Block, LZ4 | Transaction, Snappy | Transaction, LZ4 |
+  | ---: | ---: | ---: | ---: | ---: |
+  | 100,000 | 8,487,039 (84.87 B/e) | 8,486,380 (84.86 B/e) | 8,903,864 (89.04 B/e) | 8,904,184 (89.04 B/e) |
+  | 1,000,000 | 72,238,847 (72.24 B/e) | 71,885,934 (71.89 B/e) | 75,310,111 (75.31 B/e) | 75,037,601 (75.04 B/e) |
+
+  At one million entries LZ4 saves only 0.49% for `bidx` and 0.36% for `tidx`. That is not
+  enough to justify recompressing the existing block index, so `bidx` stays on Snappy while
+  the new `tidx` uses LZ4. Use **70–90 B per retained entry** as the initial planning range:
+  approximately 67 GiB per billion blocks and 70 GiB per billion transactions after
+  compaction. Reproduce with the ignored `measure_hash_index_compression_disk_size` release
+  test, then measure the deployment's real hash/key distribution and compaction state.
+
 ## 3. Interactions
 
 - **Retention × finality:** RS-2 (dominates). FINALIZE below `first(D)` is ignored (WP

--- a/crates/hotblocks/spec/11-observability.md
+++ b/crates/hotblocks/spec/11-observability.md
@@ -20,6 +20,10 @@ surface of the binding (13 §5) with bounded cardinality.
   the write pipeline stages, commit-retry counts (HZ-11), maintenance backlog size
   (HZ-2). The *existence* of a global write halt MUST be directly observable — the
   historical multi-minute freezes were diagnosable only by inference (GAP-1).
+  `hotblocks_write_duration_seconds{dataset,stage,outcome}` exposes the bounded stages
+  `prepare`, `tables`, `commit`, `retention`, `block_hash_index`, and
+  `transaction_hash_index`; hash-index samples are nested within `commit` or `retention`
+  and include work repeated by optimistic-transaction retries.
 - **OB-4 (Query metrics).** Per dataset × query class × outcome (success / each error
   class / truncation per RP-15): counts, latency distributions (TTFB, total), emitted
   bytes/blocks, coverage sizes; current in-flight and waiting counts against their caps

--- a/crates/hotblocks/spec/12-conformance-tdd.md
+++ b/crates/hotblocks/spec/12-conformance-tdd.md
@@ -261,10 +261,10 @@ the same property under forks, crashes and retention is the business of CT-2/CT-
 | INV-42 residue convergence | CT-2/7 | P | synthetic orphan purge tested; no crash-driven test |
 | INV-43 boot validation | CT-5 | U | |
 | INV-44 explicit destruction | CT-1/2 | U | |
-| INV-45 index soundness | CT-1/2 | **P** | `block_hash_index.rs`: hits match the model on ingest, unknown hashes miss, the replaced branch stops resolving. No crash or trim coverage; `tidx` unbuilt (GAP-38) |
-| INV-46 index maintenance | CT-1/4/7 | **P** | the fork path is covered black-box; trim / DROP / compaction paths have storage-level tests only (`crates/storage/tests/block_hash_index.rs`), never through the binding |
-| INV-47 fork re-inclusion | CT-4 | **U** | untestable until `tidx` exists (GAP-38); the hazard is invisible on block hashes |
-| RP-19/20 lookup contract | CT-5 | **P** | hit/miss shapes pinned; the length cap, the disabled-index case and the NOT_FOUND vs UNKNOWN_DATASET split (GAP-39) are unasserted |
+| INV-45 index soundness | CT-1/2 | **P** | `block_hash_index.rs` + `transaction_hash_index.rs`: both indexes match the model on ingest and replacement; storage tests cover trim / DROP / compaction. Crash coverage remains open |
+| INV-46 index maintenance | CT-1/4/7 | **P** | both fork paths are covered black-box; trim / DROP / compaction are storage-level only (`crates/storage/tests/{block,transaction}_hash_index.rs`) |
+| INV-47 fork re-inclusion | CT-4 | **C** | black-box reorg re-includes the same transaction at a new block and asserts the new position; storage test independently pins remove-before-insert ordering |
+| RP-19/20 lookup contract | CT-5 | **P** | hit/miss, disabled-index behavior, over-limit rejection before dataset lookup, and the 256-byte boundary are pinned; the NOT_FOUND vs UNKNOWN_DATASET split remains open (GAP-39) |
 | LIV-1/2 progress/stall | CT-6/7 | **U — known-violated** | GAP-1 |
 | LIV-3 query termination | CT-3/6 | U | |
 | LIV-4 waiter termination | CT-1/3 | P | `ct1_happy_path`: a query above the head answers `NO_DATA` within `P-HEAD-WAIT` |
@@ -283,10 +283,10 @@ the same property under forks, crashes and retention is the business of CT-2/CT-
 | FM-SRC-* corpus | CT-4 | U | one stale-pack crash-loop already occurred (GAP-5 class); no strike/quarantine substrate (GAP-30) |
 | FM-STOR-2/3 disk pressure | CT-7 | U | incident-derived; no automated test |
 | FM-OP-1..5 | CT-5 | U | |
-| SLI-1..12 / PF-* | CT-6 | U | no benchmark harness exists |
+| SLI-1..12 / PF-* | CT-6 | U | no scenario benchmark harness exists; the transaction-index ingest/lookup Criterion microbench is a component baseline only |
 | OB-1 chain gauges | CT-1 | P | `first_block` / `last_block` / `last_finalized_block` diffed against the model; commit version and retention policy not exported (GAP-34) |
 | OB-2..11 | all | P | query metrics exist; stall gauges pending on PR #83 (unmerged); OB-2 heartbeat, OB-6 debt accounting, OB-9 alarms, OB-11 forensics absent |
-| OB-12 index state | CT-1 | **U** | nothing exported: no entry count, no bytes, no hit/miss (GAP-40) |
+| OB-12 index state | CT-1 | **P** | CF-wide estimated keys / live SST bytes are exported for both indexes; per-dataset enabled/count/bytes and lookup hit/miss/latency remain absent (GAP-40) |
 
 ## 6. Gap register (dated 2026-07-12, informative)
 
@@ -333,9 +333,8 @@ rare, P3 = polish. **First test** names the cheapest failing-test-first entry po
 | GAP-35 | The runtime External instruction `"None"` parks the dataset: the controller maps it to Idle and stops ingestion even on a non-empty dataset (`RetentionStrategy::None → State::Idle`, dataset_controller.rs), while the binding documents `"None"` as Unbounded (13 §6) and WP-5 requires a non-empty dataset to keep ingesting from its window. Whether an External instruction may change the policy *mode* at all is unspecified (WP-11) | WP-5, DEF-9, WP-11, IB §6 | P2 | CT-1/CT-5: SET-RETENTION `"None"` on a non-empty External dataset; assert ingestion continues (or the instruction is refused with a defined error) — the head must keep advancing |
 | GAP-36 | `MALFORMED_REQUEST`, `RANGE_UNAVAILABLE`, `ITEM_UNAVAILABLE` and `KIND_MISMATCH` all surface as HTTP 400 with a free-text body (`api.rs error_to_response`); no machine-readable discriminant exists and IB-7 forbids keying on text — clients cannot distinguish "re-anchor upward" from "fix the request", and the CT-5 error matrix cannot verify INV-26 at the binding. 13 §5 marks the discrimination REQUIRED; the structured error body is the missing piece | INV-26, IB-7, 04 §8 | P2 | CT-5: trigger each 400 class; assert a structured field distinguishes them |
 | GAP-37 | PF-1's memory ceiling is not configuration-derivable on the read side: INV-25/RP-17 require emitting the first covered block whole even above `P-RESP-WEIGHT`, and nothing bounds a single block at ingest (`P-BATCH-BYTES` is a soft *batch* bound — one oversized block still stores), so per-response memory is bounded only by the largest block a source ever served. No `P-MAX-BLOCK-BYTES` exists | PF-1, RP-17/INV-25, FM-CLI-2 | P2 | CT-6/CT-9: ingest a pathological giant block, query it; assert bounded RSS and whole-block emission (INV-25) |
-| GAP-38 | `TX-BY-HASH` is specified (DEF-17, RP-19, IB §2) but not implemented — `tidx` does not exist. A consumer holding a bare transaction hash, which is the common case for anything reading logs or third-party feeds, has no way to reach a block number. Building it is not a variant of `bidx`: it costs one entry per *transaction* (RS-12 sizing) and it is the only index where the fork-ordering hazard of INV-47 can fire, since transaction hashes recur across branches and block hashes never do | DEF-17, RP-19, INV-47, IB §2 | P2 | CT-5: GET the transaction route (404 route-not-found today); then CT-4 re-inclusion per INV-47 |
 | GAP-39 | A hash-lookup miss and an unknown dataset are both 404 with only a free-text body between them, and IB-7 forbids keying on text. This is worse than the GAP-36 family it belongs to: RP-19 makes "this hash is not indexed" a *deliberately uninformative* answer, so a client that cannot separate it from "this dataset does not exist" cannot tell a misconfiguration from a legitimate miss at all | INV-26, IB-7, RP-19 | P3 | CT-5: unknown dataset vs unknown hash; assert a structured discriminant |
-| GAP-40 | The hash indexes export nothing (OB-12): no entry count, no bytes toward OB-6/RS-12, no hit/miss rate. Because a miss is uninformative by design, an index that is empty for a structural reason — enabled after the window had filled, wrong kind — is indistinguishable in production from one nobody queries. The `--block-hash-index` flag can be on, the endpoint can 404 every request, and no signal says so | OB-12, OB-6 | P3 | CT-1: scrape assertion once exported |
+| GAP-40 | Hash-index CFs export only engine-wide estimated keys and live SST bytes. OB-12 still lacks per-dataset enabled state / entry count / bytes and hit-vs-miss lookup counts with latency. Because a miss is uninformative by design, an index empty for a structural reason — enabled after the window had filled, wrong kind — remains indistinguishable from one receiving only unknown hashes | OB-12, OB-6 | P3 | CT-1: scrape per-dataset state and exercise hit/miss counters once exported |
 
 ### 6.1 Closed
 
@@ -343,6 +342,7 @@ rare, P3 = polish. **First test** names the cheapest failing-test-first entry po
 |---|---|---|
 | GAP-16 | No service-level automated tests | [`crates/hotblocks-harness`](../../hotblocks-harness) + `ct1_happy_path` (Phase 0, 2026-07-12) |
 | GAP-19 | A source response whose final JSONL record carried no trailing newline panicked the line reader (`LineStream::take_final_line` left its scan position past the emptied buffer). The ingest task died, its buffered batch was lost, and the dataset parked for `P-EPOCH-RETRY` — then crash-looped, since the source served the same body on retry. Violated FM-1, LIV-2 | Found by CT-1 on the harness's first run; fixed in `crates/data-client/src/reqwest/lines.rs`; pinned by a unit test there and by `ct9_source_faults` (2026-07-12) |
+| GAP-38 | `TX-BY-HASH` / `tidx` absent; fork re-inclusion ordering unimplemented | Transaction hash CF + independent flag + HTTP binding; storage transition suite and black-box ingest/reorg/re-inclusion tests (2026-07-15) |
 
 ## 7. Build order (recommended)
 

--- a/crates/hotblocks/spec/13-interface-binding.md
+++ b/crates/hotblocks/spec/13-interface-binding.md
@@ -29,7 +29,7 @@ annotated with the relevant GAP.
 | FINALIZED-HEAD | `GET /datasets/{id}/finalized-head` | same shape |
 | STATUS | `GET /datasets/{id}/status` | kind, retention, first/last block (+hash/time), finalized head |
 | BLOCK-BY-HASH | `GET /datasets/{id}/hashes/{hash}/block` | `{"number":N,"hash":"…"}`; miss = `NOT_FOUND`, **not** proof of absence (RP-19) |
-| TX-BY-HASH | `GET /datasets/{id}/hashes/{hash}/transaction` | `{"blockNumber":N,"transactionIndex":i,"hash":"…"}` — **not implemented** (GAP-38) |
+| TX-BY-HASH | `GET /datasets/{id}/hashes/{hash}/transaction` | `{"blockNumber":N,"transactionIndex":i,"hash":"…"}`; miss = `NOT_FOUND`, **not** proof of absence (RP-19) |
 | METADATA | `GET /datasets/{id}/metadata` | start block, real-time flag, aliases |
 | GET-RETENTION | `GET /datasets/{id}/retention` | current policy JSON |
 | SET-RETENTION | `POST /datasets/{id}/retention` | policy JSON; only for `External` datasets, else `FORBIDDEN` (403) |

--- a/crates/hotblocks/spec/14-parameters.md
+++ b/crates/hotblocks/spec/14-parameters.md
@@ -20,7 +20,7 @@ ran against.
 | `P-EXEC-SLOTS` | global concurrent query work units (RP-3, PF-3) | executor threads × 200 | keep; revisit per-dataset fairness (GAP-14) |
 | `P-WAITERS` | global cap on head-waiting queries (RP-5) | 64 000 | keep; same fairness note |
 | `P-SCHED-SLACK` | scheduling tolerance added to termination bounds (LIV-3/4) | — | 1 s ⚠ |
-| `P-HASH-MAXLEN` | max accepted hash length on a lookup, rejected before store access (RP-20) | 256 chars | keep |
+| `P-HASH-MAXLEN` | max accepted hash length on a lookup, rejected before store access (RP-20) | 256 UTF-8 bytes | keep |
 
 ## Write path
 
@@ -49,7 +49,7 @@ ran against.
 | `P-RECLAIM-LAG` | logical delete → physical space convergence (LIV-7) | sweep ≤ 10 s + compaction (typically minutes–hours); ≤ 7 d worst case via periodic compaction; interrupted-build residue: ∞ in default config (GAP-6) | ≤ 24 h ⚠ |
 | `P-DISK-FLOOR` | free-disk alarm/degrade threshold (FM-STOR-2) | — | define ⚠ |
 | `P-BLOCK-INDEX` | block hash index enabled (DEF-17, RS-12) | off by default (`--block-hash-index`); EVM only | keep |
-| `P-TX-INDEX` | transaction hash index enabled (DEF-17, RS-12) | absent — not implemented (GAP-38) | define ⚠; must stay independent of `P-BLOCK-INDEX` (RS-12 sizing asymmetry) |
+| `P-TX-INDEX` | transaction hash index enabled (DEF-17, RS-12) | off by default (`--transaction-hash-index`); EVM only; independent of `P-BLOCK-INDEX` | keep |
 
 ## Liveness, durability, lifecycle
 

--- a/crates/hotblocks/src/api.rs
+++ b/crates/hotblocks/src/api.rs
@@ -62,6 +62,7 @@ pub fn build_api(app: App) -> Router {
         .route("/datasets/{id}/head", get(get_head))
         .route("/datasets/{id}/finalized-head", get(get_finalized_head))
         .route("/datasets/{id}/hashes/{hash}/block", get(get_block_by_hash))
+        .route("/datasets/{id}/hashes/{hash}/transaction", get(get_transaction_by_hash))
         .route("/datasets/{id}/retention", get(get_retention).post(set_retention))
         .route("/datasets/{id}/status", get(get_status))
         .route("/datasets/{id}/metadata", get(get_metadata))
@@ -72,6 +73,25 @@ pub fn build_api(app: App) -> Router {
         .layer(axum::middleware::from_fn(middleware))
         .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid::default()))
         .layer(Extension(Arc::new(app)))
+}
+
+const HASH_MAX_LEN: usize = 256;
+
+fn invalid_hash(hash: &str) -> bool {
+    hash.is_empty() || hash.len() > HASH_MAX_LEN
+}
+
+#[cfg(test)]
+mod hash_validation_tests {
+    use super::*;
+
+    #[test]
+    fn invalid_hash_counts_utf8_bytes_at_the_256_byte_boundary() {
+        assert!(invalid_hash(""));
+        assert!(!invalid_hash(&"x".repeat(HASH_MAX_LEN)));
+        assert!(!invalid_hash(&"é".repeat(HASH_MAX_LEN / 2)));
+        assert!(invalid_hash(&"é".repeat(HASH_MAX_LEN / 2 + 1)));
+    }
 }
 
 pub async fn middleware(mut req: Request, next: axum::middleware::Next) -> impl IntoResponse {
@@ -377,8 +397,8 @@ async fn get_block_by_hash(
     Extension(client_id): Extension<ClientId>,
     Path((dataset_id, hash)): Path<(DatasetId, String)>
 ) -> impl IntoResponse {
-    // Reject absurd lengths before touching the DB (real hashes are 64-88 chars).
-    if hash.is_empty() || hash.len() > 256 {
+    // Reject absurd lengths before touching the DB (real hashes are 64-88 bytes).
+    if invalid_hash(&hash) {
         return ResponseWithMetadata::new()
             .with_client_id(&client_id)
             .with_dataset_id(dataset_id)
@@ -410,6 +430,47 @@ async fn get_block_by_hash(
         .with_client_id(&client_id)
         .with_dataset_id(dataset_id)
         .with_endpoint("/hashes/{hash}/block")
+        .with_response(|| response)
+}
+
+async fn get_transaction_by_hash(
+    Extension(app): Extension<AppRef>,
+    Extension(client_id): Extension<ClientId>,
+    Path((dataset_id, hash)): Path<(DatasetId, String)>
+) -> impl IntoResponse {
+    // Reject absurd lengths before touching the DB (real hashes are 64-88 bytes).
+    if invalid_hash(&hash) {
+        return ResponseWithMetadata::new()
+            .with_client_id(&client_id)
+            .with_dataset_id(dataset_id)
+            .with_endpoint("/hashes/{hash}/transaction")
+            .with_response(|| text!(StatusCode::BAD_REQUEST, "invalid hash length"));
+    }
+
+    let dataset = match app.data_service.get_dataset(dataset_id) {
+        Ok(ds) => ds,
+        Err(err) => {
+            return ResponseWithMetadata::new()
+                .with_client_id(&client_id)
+                .with_dataset_id(dataset_id)
+                .with_endpoint("/hashes/{hash}/transaction")
+                .with_response(|| text!(StatusCode::NOT_FOUND, "{}", err));
+        }
+    };
+
+    let response = match dataset.get_transaction_by_hash(hash).await {
+        Ok(Some(transaction_ref)) => json_ok!(transaction_ref),
+        Ok(None) => text!(StatusCode::NOT_FOUND, "transaction not found"),
+        Err(err) => {
+            error!(error = ?err, dataset_id = %dataset_id, "get_transaction_by_hash failed");
+            text!(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        }
+    };
+
+    ResponseWithMetadata::new()
+        .with_client_id(&client_id)
+        .with_dataset_id(dataset_id)
+        .with_endpoint("/hashes/{hash}/transaction")
         .with_response(|| response)
 }
 

--- a/crates/hotblocks/src/cli.rs
+++ b/crates/hotblocks/src/cli.rs
@@ -94,6 +94,15 @@ pub struct CLI {
     #[arg(long)]
     pub block_hash_index: bool,
 
+    /// Index transaction hashes of newly ingested chunks, enabling
+    /// `GET /datasets/{id}/hashes/{hash}/transaction`. EVM datasets only.
+    ///
+    /// Independent of `--block-hash-index` and off by default because this
+    /// index has one entry per transaction. No backfill; entries drain through
+    /// retention after switching it off.
+    #[arg(long)]
+    pub transaction_hash_index: bool,
+
     /// Known client IDs for metrics labeling. Client IDs not in this list
     /// will be reported as "unknown" to prevent metrics cardinality abuse.
     #[arg(long = "known-client", value_name = "ID")]
@@ -120,7 +129,8 @@ impl CLI {
             .with_max_log_file_size(self.rocksdb_max_log_file_size)
             .with_keep_log_file_num(self.rocksdb_keep_log_file_num)
             .with_periodic_compaction_secs(self.rocksdb_periodic_compaction_secs)
-            .with_block_hash_index(self.block_hash_index);
+            .with_block_hash_index(self.block_hash_index)
+            .with_transaction_hash_index(self.transaction_hash_index);
 
         if let Some(jobs) = self.rocksdb_max_background_jobs {
             settings = settings.with_max_background_jobs(jobs);

--- a/crates/hotblocks/src/dataset_controller/dataset_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/dataset_controller.rs
@@ -1,10 +1,14 @@
-use std::{collections::BTreeMap, ops::Add, time::Duration};
+use std::{
+    collections::BTreeMap,
+    ops::Add,
+    time::{Duration, Instant as StdInstant}
+};
 
 use anyhow::{Context, anyhow};
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
 use sqd_data_client::reqwest::ReqwestDataClient;
-use sqd_primitives::{BlockNumber, BlockRef};
-use sqd_storage::db::{Chunk, CompactionStatus, DatasetId};
+use sqd_primitives::{BlockNumber, BlockRef, TransactionRef};
+use sqd_storage::db::{Chunk, CompactionStatus, DatasetId, HashIndexWriteMetrics};
 use tokio::{select, task::JoinHandle, time::Instant};
 use tracing::{Instrument, debug, error, info, info_span, instrument, warn};
 
@@ -14,6 +18,7 @@ use crate::{
         ingest_generic::{IngestMessage, NewChunk},
         write_controller::WriteController
     },
+    metrics::{WriteStage, report_hash_index_write_metrics, report_write_duration},
     types::{DBRef, DatasetKind, RetentionStrategy}
 };
 
@@ -48,7 +53,9 @@ impl DatasetController {
         let mut write = WriteController::new(db.clone(), dataset_id, dataset_kind)?;
 
         if let RetentionStrategy::FromBlock { number, parent_hash } = &retention {
-            write.init_retention(*number, parent_hash.clone())?;
+            observe_storage_write(dataset_id, WriteStage::Retention, |metrics| {
+                write.init_retention(*number, parent_hash.clone(), metrics)
+            })?;
         }
 
         let (retention_sender, retention_recv) = tokio::sync::watch::channel(retention);
@@ -117,6 +124,17 @@ impl DatasetController {
             .context("get_block_by_hash task panicked")?
     }
 
+    /// Resolves a transaction hash to its canonical position through the
+    /// storage index. The synchronous RocksDB point read stays off Tokio's
+    /// runtime workers and does not consume range-query execution slots.
+    pub async fn get_transaction_by_hash(&self, hash: String) -> anyhow::Result<Option<TransactionRef>> {
+        let db = self.db.clone();
+        let dataset_id = self.dataset_id;
+        tokio::task::spawn_blocking(move || db.snapshot().find_transaction_by_hash(dataset_id, &hash))
+            .await
+            .context("get_transaction_by_hash task panicked")?
+    }
+
     pub fn enable_compaction(&self, yes: bool) {
         let _ = self.compaction_enabled_sender.send(yes);
     }
@@ -156,6 +174,7 @@ impl DatasetController {
 
 struct WriteCtx {
     db: DBRef,
+    dataset_id: DatasetId,
     write: WriteController,
     head_sender: tokio::sync::watch::Sender<Option<BlockRef>>,
     finalized_head_sender: tokio::sync::watch::Sender<Option<BlockRef>>
@@ -197,23 +216,30 @@ impl WriteCtx {
 
     fn write_new_chunk(&mut self, mut new_chunk: NewChunk) -> anyhow::Result<()> {
         let desc = self.write.dataset_kind().dataset_description();
-        let mut tables = BTreeMap::new();
+        let started = StdInstant::now();
+        let tables: anyhow::Result<_> = (|| {
+            let mut tables = BTreeMap::new();
 
-        for (name, prepared) in new_chunk.tables.iter_mut() {
-            let mut builder = self.db.new_table_builder(prepared.schema());
+            for (name, prepared) in new_chunk.tables.iter_mut() {
+                let mut builder = self.db.new_table_builder(prepared.schema());
 
-            if let Some(table_desc) = desc.tables.get(name) {
-                for (&col, opts) in table_desc.options.column_options.iter() {
-                    if opts.stats_enable {
-                        builder.add_stat_by_name(col)?;
+                if let Some(table_desc) = desc.tables.get(name) {
+                    for (&col, opts) in table_desc.options.column_options.iter() {
+                        if opts.stats_enable {
+                            builder.add_stat_by_name(col)?;
+                        }
                     }
                 }
+
+                prepared.read(&mut builder, 0, prepared.num_rows())?;
+
+                tables.insert(name.to_string(), builder.finish()?);
             }
 
-            prepared.read(&mut builder, 0, prepared.num_rows())?;
-
-            tables.insert(name.to_string(), builder.finish()?);
-        }
+            Ok(tables)
+        })();
+        report_write_duration(self.dataset_id, WriteStage::Tables, started.elapsed(), tables.is_ok());
+        let tables = tables?;
 
         let chunk = Chunk::V1 {
             parent_block_hash: new_chunk.parent_block_hash,
@@ -225,11 +251,15 @@ impl WriteCtx {
             tables
         };
 
-        self.write.new_chunk(new_chunk.finalized_head.as_ref(), &chunk)
+        observe_storage_write(self.dataset_id, WriteStage::Commit, |metrics| {
+            self.write.new_chunk(new_chunk.finalized_head.as_ref(), &chunk, metrics)
+        })
     }
 
     fn retain(&mut self, from_block: BlockNumber, parent_hash: Option<String>) -> anyhow::Result<()> {
-        self.write.retain(from_block, parent_hash)?;
+        observe_storage_write(self.dataset_id, WriteStage::Retention, |metrics| {
+            self.write.retain(from_block, parent_hash, metrics)
+        })?;
         self.notify_finalized_head();
         self.notify_head();
         Ok(())
@@ -498,6 +528,7 @@ impl Ctl {
 
         let task = tokio::spawn(
             ingest(
+                self.dataset_id,
                 msg_sender,
                 self.data_sources.clone(),
                 self.dataset_kind,
@@ -529,11 +560,26 @@ impl Ctl {
 
         Ok(WriteCtx {
             db: self.db.clone(),
+            dataset_id: self.dataset_id,
             write,
             head_sender: self.head_sender.clone(),
             finalized_head_sender: self.finalized_head_sender.clone()
         })
     }
+}
+
+fn observe_storage_write<R>(
+    dataset_id: DatasetId,
+    stage: WriteStage,
+    write: impl FnOnce(&mut HashIndexWriteMetrics) -> anyhow::Result<R>
+) -> anyhow::Result<R> {
+    let mut hash_metrics = HashIndexWriteMetrics::default();
+    let started = StdInstant::now();
+    let result = write(&mut hash_metrics);
+    let success = result.is_ok();
+    report_write_duration(dataset_id, stage, started.elapsed(), success);
+    report_hash_index_write_metrics(dataset_id, &hash_metrics, success);
+    result
 }
 
 async fn fetch_chain_top(clients: Vec<ReqwestDataClient>) -> BlockNumber {

--- a/crates/hotblocks/src/dataset_controller/ingest.rs
+++ b/crates/hotblocks/src/dataset_controller/ingest.rs
@@ -4,6 +4,7 @@ use serde::de::DeserializeOwned;
 use sqd_data_client::reqwest::ReqwestDataClient;
 use sqd_data_source::{DataSource, StandardDataSource};
 use sqd_primitives::BlockNumber;
+use sqd_storage::db::DatasetId;
 
 use crate::{
     dataset_controller::ingest_generic::{IngestGeneric, IngestMessage},
@@ -11,6 +12,7 @@ use crate::{
 };
 
 pub fn ingest<'a, 'b>(
+    dataset_id: DatasetId,
     message_sender: tokio::sync::mpsc::Sender<IngestMessage>,
     sources: Vec<ReqwestDataClient>,
     dataset_kind: DatasetKind,
@@ -21,7 +23,9 @@ pub fn ingest<'a, 'b>(
         ($builder:expr) => {{
             let mut data_source = StandardDataSource::new(sources, from_json_bytes);
             data_source.set_position(first_block, parent_block_hash);
-            IngestGeneric::new(data_source, $builder, message_sender).run().boxed()
+            IngestGeneric::new(dataset_id, data_source, $builder, message_sender)
+                .run()
+                .boxed()
         }};
     }
 

--- a/crates/hotblocks/src/dataset_controller/ingest_generic.rs
+++ b/crates/hotblocks/src/dataset_controller/ingest_generic.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    time::Instant
+};
 
 use anyhow::{anyhow, ensure};
 use chrono::{DateTime, Utc};
@@ -6,9 +9,13 @@ use futures::StreamExt;
 use sqd_data_core::{BlockChunkBuilder, ChunkProcessor, PreparedChunk};
 use sqd_data_source::{DataEvent, DataSource};
 use sqd_primitives::{Block, BlockNumber, BlockRef, DataMask, DisplayBlockRefOption};
+use sqd_storage::db::DatasetId;
 use tracing::{debug, field::valuable, info};
 
-use crate::dataset_controller::write_controller::Rollback;
+use crate::{
+    dataset_controller::write_controller::Rollback,
+    metrics::{WriteStage, report_write_duration}
+};
 
 pub enum IngestMessage {
     FinalizedHead(BlockRef),
@@ -90,6 +97,7 @@ impl<CB: BlockChunkBuilder> DataBuilder<CB> {
 }
 
 pub struct IngestGeneric<DC, CB> {
+    dataset_id: DatasetId,
     message_sender: tokio::sync::mpsc::Sender<IngestMessage>,
     data_source: DC,
     builder: Option<DataBuilder<CB>>,
@@ -109,9 +117,15 @@ where
     DS: DataSource,
     CB: BlockChunkBuilder<Block = DS::Block> + Send + 'static
 {
-    pub fn new(data_source: DS, chunk_builder: CB, message_sender: tokio::sync::mpsc::Sender<IngestMessage>) -> Self {
+    pub fn new(
+        dataset_id: DatasetId,
+        data_source: DS,
+        chunk_builder: CB,
+        message_sender: tokio::sync::mpsc::Sender<IngestMessage>
+    ) -> Self {
         let first_block = data_source.get_next_block();
         Self {
+            dataset_id,
             message_sender,
             data_source,
             builder: Some(DataBuilder::new(chunk_builder)),
@@ -239,7 +253,10 @@ where
             "received new chunk"
         );
 
-        let mut tables = self.with_blocking_builder(|b| b.finish()).await?;
+        let started = Instant::now();
+        let tables = self.with_blocking_builder(|b| b.finish()).await;
+        report_write_duration(self.dataset_id, WriteStage::Prepare, started.elapsed(), tables.is_ok());
+        let mut tables = tables?;
 
         tables.retain(|&name, _| CB::Block::has_data(self.data_mask, name));
 

--- a/crates/hotblocks/src/dataset_controller/write_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/write_controller.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, ensure};
 use sqd_primitives::{BlockNumber, BlockRef};
-use sqd_storage::db::{Chunk as StorageChunk, Chunk, DatasetId};
+use sqd_storage::db::{Chunk as StorageChunk, Chunk, DatasetId, HashIndexWriteMetrics};
 use tracing::{debug, field::valuable, info, instrument, warn};
 
 use crate::types::{DBRef, DatasetKind};
@@ -147,7 +147,8 @@ impl WriteController {
         &mut self,
         from_block: BlockNumber,
         parent_block_hash: Option<String>,
-        delete_mismatch: bool
+        delete_mismatch: bool,
+        metrics: &mut HashIndexWriteMetrics
     ) -> anyhow::Result<()> {
         #[derive(Eq, PartialEq)]
         enum Status {
@@ -161,72 +162,74 @@ impl WriteController {
             Clear
         }
 
-        let status = self.db.update_dataset(self.dataset_id, |tx| {
-            let mut status = Status::Clear;
-            for chunk_result in tx.list_chunks(0, None) {
-                let chunk = chunk_result?;
-                if chunk.last_block() < from_block {
-                    tx.delete_chunk(&chunk)?;
-                } else if from_block < chunk.first_block() {
-                    if delete_mismatch {
+        let status = self
+            .db
+            .update_dataset_with_hash_index_metrics(self.dataset_id, metrics, |tx| {
+                let mut status = Status::Clear;
+                for chunk_result in tx.list_chunks(0, None) {
+                    let chunk = chunk_result?;
+                    if chunk.last_block() < from_block {
                         tx.delete_chunk(&chunk)?;
-                    } else {
-                        bail!(
-                            "there is a gap between first requested block {} and already existing chunk {}, \
-                            that could not be filled",
-                            from_block,
-                            chunk
-                        );
-                    }
-                    if status == Status::Clear {
-                        status = Status::Gap(chunk.first_block());
-                    }
-                } else {
-                    let hash_check = if let Some(parent_block_hash) = parent_block_hash.as_ref() {
-                        tx.validate_parent_block_hash(&chunk, from_block, parent_block_hash)?
-                    } else {
-                        Ok(())
-                    };
-                    if let Some(actual_hash) = hash_check.err() {
+                    } else if from_block < chunk.first_block() {
                         if delete_mismatch {
                             tx.delete_chunk(&chunk)?;
-                            status = Status::HashMismatch;
                         } else {
                             bail!(
-                                "hash mismatch: expected the parent of {} to have hash {}, but got {}",
+                                "there is a gap between first requested block {} and already existing chunk {}, \
+                            that could not be filled",
                                 from_block,
-                                parent_block_hash.as_ref().unwrap(),
-                                actual_hash
+                                chunk
                             );
                         }
-                    } else {
-                        let head = tx
-                            .list_chunks(0, None)
-                            .into_reversed()
-                            .next()
-                            .expect("bottom chunk can't exist without head chunk")?;
-
-                        let finalized_head = tx
-                            .label()
-                            .finalized_head()
-                            .filter(|h| chunk.first_block() <= h.number)
-                            .cloned();
-
-                        if finalized_head.is_none() {
-                            tx.set_finalized_head(None)
+                        if status == Status::Clear {
+                            status = Status::Gap(chunk.first_block());
                         }
+                    } else {
+                        let hash_check = if let Some(parent_block_hash) = parent_block_hash.as_ref() {
+                            tx.validate_parent_block_hash(&chunk, from_block, parent_block_hash)?
+                        } else {
+                            Ok(())
+                        };
+                        if let Some(actual_hash) = hash_check.err() {
+                            if delete_mismatch {
+                                tx.delete_chunk(&chunk)?;
+                                status = Status::HashMismatch;
+                            } else {
+                                bail!(
+                                    "hash mismatch: expected the parent of {} to have hash {}, but got {}",
+                                    from_block,
+                                    parent_block_hash.as_ref().unwrap(),
+                                    actual_hash
+                                );
+                            }
+                        } else {
+                            let head = tx
+                                .list_chunks(0, None)
+                                .into_reversed()
+                                .next()
+                                .expect("bottom chunk can't exist without head chunk")?;
 
-                        return Ok(Status::Range {
-                            first_chunk: chunk,
-                            head,
-                            finalized_head
-                        });
+                            let finalized_head = tx
+                                .label()
+                                .finalized_head()
+                                .filter(|h| chunk.first_block() <= h.number)
+                                .cloned();
+
+                            if finalized_head.is_none() {
+                                tx.set_finalized_head(None)
+                            }
+
+                            return Ok(Status::Range {
+                                first_chunk: chunk,
+                                head,
+                                finalized_head
+                            });
+                        }
                     }
                 }
-            }
-            tx.set_finalized_head(None);
-            Ok(status)
-        })?;
+                tx.set_finalized_head(None);
+                Ok(status)
+            })?;
 
         match status {
             Status::Range {
@@ -271,12 +274,22 @@ impl WriteController {
         self.first_chunk_head = None;
     }
 
-    pub fn retain(&mut self, from_block: BlockNumber, parent_block_hash: Option<String>) -> anyhow::Result<()> {
-        self._retain(from_block, parent_block_hash, true)
+    pub fn retain(
+        &mut self,
+        from_block: BlockNumber,
+        parent_block_hash: Option<String>,
+        metrics: &mut HashIndexWriteMetrics
+    ) -> anyhow::Result<()> {
+        self._retain(from_block, parent_block_hash, true, metrics)
     }
 
-    pub fn init_retention(&mut self, from_block: BlockNumber, parent_block_hash: Option<String>) -> anyhow::Result<()> {
-        self._retain(from_block, parent_block_hash, false)
+    pub fn init_retention(
+        &mut self,
+        from_block: BlockNumber,
+        parent_block_hash: Option<String>,
+        metrics: &mut HashIndexWriteMetrics
+    ) -> anyhow::Result<()> {
+        self._retain(from_block, parent_block_hash, false, metrics)
     }
 
     #[instrument(skip_all, fields(
@@ -343,32 +356,39 @@ impl WriteController {
         last_block_hash = %chunk.last_block_hash(),
         finalized_head = valuable(&finalized_head),
     ))]
-    pub fn new_chunk(&mut self, finalized_head: Option<&BlockRef>, chunk: &StorageChunk) -> anyhow::Result<()> {
+    pub fn new_chunk(
+        &mut self,
+        finalized_head: Option<&BlockRef>,
+        chunk: &StorageChunk,
+        metrics: &mut HashIndexWriteMetrics
+    ) -> anyhow::Result<()> {
         // FIXME: accept self.first_block rollback limit
-        let finalized_head = self.db.update_dataset(self.dataset_id, |tx| {
-            let new_finalized_head = match (finalized_head, tx.label().finalized_head()) {
-                (Some(new), None) => Some(new),
-                (Some(new), Some(current)) if new.number >= current.number => Some(new),
-                (_, Some(current)) if current.number < chunk.first_block() => Some(current),
-                (_, Some(_)) => bail!(
-                    "can't fork safely, because fork base is below the current finalized head \
+        let finalized_head = self
+            .db
+            .update_dataset_with_hash_index_metrics(self.dataset_id, metrics, |tx| {
+                let new_finalized_head = match (finalized_head, tx.label().finalized_head()) {
+                    (Some(new), None) => Some(new),
+                    (Some(new), Some(current)) if new.number >= current.number => Some(new),
+                    (_, Some(current)) if current.number < chunk.first_block() => Some(current),
+                    (_, Some(_)) => bail!(
+                        "can't fork safely, because fork base is below the current finalized head \
                     and finalized head of the data pack is below the current"
-                ),
-                (None, None) => None
-            };
+                    ),
+                    (None, None) => None
+                };
 
-            let new_finalized_head = new_finalized_head.map(|head| {
-                if head.number < chunk.last_block() {
-                    head.clone()
-                } else {
-                    get_chunk_head(&chunk)
-                }
-            });
+                let new_finalized_head = new_finalized_head.map(|head| {
+                    if head.number < chunk.last_block() {
+                        head.clone()
+                    } else {
+                        get_chunk_head(&chunk)
+                    }
+                });
 
-            tx.set_finalized_head(new_finalized_head.clone());
-            tx.insert_fork(chunk)?;
-            Ok(new_finalized_head)
-        })?;
+                tx.set_finalized_head(new_finalized_head.clone());
+                tx.insert_fork(chunk)?;
+                Ok(new_finalized_head)
+            })?;
 
         debug!(finalized_head = valuable(&finalized_head), "saved new chunk");
 

--- a/crates/hotblocks/src/main.rs
+++ b/crates/hotblocks/src/main.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use api::build_api;
 use clap::Parser;
 use cli::CLI;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, info, instrument};
 use types::DBRef;
 
 #[global_allocator]
@@ -40,12 +40,13 @@ fn main() -> anyhow::Result<()> {
             // NB: startup disk recovery (orphan purge + file unlink, gated by
             // --startup-disk-reclaim) already ran inside `build_app` -> `DataService::start`,
             // before any controller spawned.
-
             tokio::spawn(db_cleanup_task(app.db.clone()));
 
             let api = build_api(app);
 
             let listener = tokio::net::TcpListener::bind(("0.0.0.0", args.port)).await?;
+
+            info!("server started, listening at {}", listener.local_addr()?);
 
             axum::serve(listener, api)
                 .with_graceful_shutdown(shutdown_signal())

--- a/crates/hotblocks/src/metrics.rs
+++ b/crates/hotblocks/src/metrics.rs
@@ -12,7 +12,10 @@ use prometheus_client::{
     },
     registry::Registry
 };
-use sqd_storage::db::{CF_CHUNKS, CF_DATASETS, CF_DELETED_TABLES, CF_DIRTY_TABLES, CF_TABLES, DatasetId, ReadSnapshot};
+use sqd_storage::db::{
+    CF_BLOCK_HASHES, CF_CHUNKS, CF_DATASETS, CF_DELETED_TABLES, CF_DIRTY_TABLES, CF_TABLES, CF_TRANSACTION_HASHES,
+    DatasetId, HashIndexWriteMetrics, ReadSnapshot
+};
 use tracing::error;
 
 use crate::{query::QueryExecutorCollector, types::DBRef};
@@ -73,6 +76,82 @@ pub static QUERIED_BLOCKS: LazyLock<Family<Labels, Histogram>> =
     LazyLock::new(|| Family::new_with_constructor(|| Histogram::new(exponential_buckets(1., 2.0, 30))));
 pub static QUERIED_CHUNKS: LazyLock<Family<Labels, Histogram>> =
     LazyLock::new(|| Family::new_with_constructor(|| Histogram::new(buckets(1., 20))));
+
+#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq)]
+pub(crate) enum WriteStage {
+    Prepare,
+    Tables,
+    Commit,
+    Retention,
+    BlockHashIndex,
+    TransactionHashIndex
+}
+
+impl WriteStage {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepare => "prepare",
+            Self::Tables => "tables",
+            Self::Commit => "commit",
+            Self::Retention => "retention",
+            Self::BlockHashIndex => "block_hash_index",
+            Self::TransactionHashIndex => "transaction_hash_index"
+        }
+    }
+}
+
+impl EncodeLabelValue for WriteStage {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.write_str(self.as_str())
+    }
+}
+
+#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq)]
+enum WriteOutcome {
+    Success,
+    Error
+}
+
+impl EncodeLabelValue for WriteOutcome {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.write_str(match self {
+            Self::Success => "success",
+            Self::Error => "error"
+        })
+    }
+}
+
+#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq, EncodeLabelSet)]
+struct WriteLabels {
+    dataset: DatasetValue,
+    stage: WriteStage,
+    outcome: WriteOutcome
+}
+
+static WRITE_DURATION: LazyLock<Family<WriteLabels, Histogram>> =
+    LazyLock::new(|| Family::new_with_constructor(|| Histogram::new(buckets(0.0001, 28))));
+
+pub(crate) fn report_write_duration(dataset_id: DatasetId, stage: WriteStage, duration: Duration, success: bool) {
+    let labels = WriteLabels {
+        dataset: DatasetValue(dataset_id),
+        stage,
+        outcome: if success {
+            WriteOutcome::Success
+        } else {
+            WriteOutcome::Error
+        }
+    };
+    WRITE_DURATION.get_or_create(&labels).observe(duration.as_secs_f64());
+}
+
+pub(crate) fn report_hash_index_write_metrics(dataset_id: DatasetId, metrics: &HashIndexWriteMetrics, success: bool) {
+    if let Some(duration) = metrics.block_hash_index_duration() {
+        report_write_duration(dataset_id, WriteStage::BlockHashIndex, duration, success);
+    }
+    if let Some(duration) = metrics.transaction_hash_index_duration() {
+        report_write_duration(dataset_id, WriteStage::TransactionHashIndex, duration, success);
+    }
+}
 
 pub fn report_query_too_many_tasks_error() {
     QUERY_ERROR_TOO_MANY_TASKS.inc();
@@ -171,7 +250,7 @@ fn collect_dataset_metrics(
 /// RocksDB write-pressure and maintenance gauges collected from intrinsic properties.
 ///
 /// Property reads happen only during a Prometheus scrape and do not require RocksDB's
-/// optional statistics collection. Labels are bounded by the five configured column
+/// optional statistics collection. Labels are bounded by the configured column
 /// families.
 #[derive(Debug)]
 pub struct RocksDbCollector {
@@ -297,7 +376,15 @@ const ROCKSDB_PER_CF: &[RocksDbPropertyMetric] = &[
     }
 ];
 
-const ROCKSDB_COLUMN_FAMILIES: &[&str] = &[CF_DATASETS, CF_CHUNKS, CF_TABLES, CF_DIRTY_TABLES, CF_DELETED_TABLES];
+const ROCKSDB_COLUMN_FAMILIES: &[&str] = &[
+    CF_DATASETS,
+    CF_CHUNKS,
+    CF_TABLES,
+    CF_DIRTY_TABLES,
+    CF_DELETED_TABLES,
+    CF_BLOCK_HASHES,
+    CF_TRANSACTION_HASHES
+];
 
 #[derive(Copy, Clone, Hash, Debug, Eq, PartialEq, EncodeLabelSet)]
 struct ColumnFamilyLabel {
@@ -372,6 +459,11 @@ pub fn build_metrics_registry() -> Registry {
         "Time to first byte of HTTP responses",
         HTTP_TTFB.clone()
     );
+    registry.register(
+        "write_duration_seconds",
+        "Write-pipeline stage duration; hash-index stages are nested within commit or retention",
+        WRITE_DURATION.clone()
+    );
 
     registry.register("stream_bytes", "Number of bytes per stream", STREAM_BYTES.clone());
     registry.register("stream_blocks", "Number of blocks per stream", STREAM_BLOCKS.clone());
@@ -440,6 +532,50 @@ mod tests {
     use sqd_storage::db::{Chunk, DatabaseSettings, DatasetId, DatasetKind};
 
     use super::*;
+
+    #[test]
+    fn write_duration_exposes_bounded_stage_and_outcome_labels() {
+        let dataset_id = DatasetId::from_str("write-metrics-test");
+        let stages = [
+            WriteStage::Prepare,
+            WriteStage::Tables,
+            WriteStage::Commit,
+            WriteStage::Retention,
+            WriteStage::BlockHashIndex,
+            WriteStage::TransactionHashIndex
+        ];
+
+        for stage in stages {
+            report_write_duration(dataset_id, stage, Duration::from_millis(1), true);
+        }
+        report_write_duration(dataset_id, WriteStage::Commit, Duration::from_millis(2), false);
+
+        let registry = build_metrics_registry();
+        let mut output = String::new();
+        prometheus_client::encoding::text::encode(&mut output, &registry).unwrap();
+
+        for stage in stages {
+            assert!(
+                output.lines().any(|line| {
+                    line.starts_with("hotblocks_write_duration_seconds_count")
+                        && line.contains("dataset=\"write-metrics-test\"")
+                        && line.contains(&format!("stage=\"{}\"", stage.as_str()))
+                        && line.contains("outcome=\"success\"")
+                }),
+                "missing successful {} stage:\n{output}",
+                stage.as_str()
+            );
+        }
+        assert!(
+            output.lines().any(|line| {
+                line.starts_with("hotblocks_write_duration_seconds_count")
+                    && line.contains("dataset=\"write-metrics-test\"")
+                    && line.contains("stage=\"commit\"")
+                    && line.contains("outcome=\"error\"")
+            }),
+            "missing error outcome:\n{output}"
+        );
+    }
 
     #[test]
     fn rocksdb_collector_exposes_global_and_per_cf_properties() {

--- a/crates/hotblocks/tests/block_hash_index.rs
+++ b/crates/hotblocks/tests/block_hash_index.rs
@@ -46,6 +46,11 @@ async fn assert_ingest_lookup(h: &mut Harness) -> Result<()> {
         None,
         "a hash outside the ingested chain must return 404"
     );
+    assert_eq!(
+        h.client.block_by_hash_status(&"é".repeat(256)).await?,
+        400,
+        "the existing block endpoint must enforce the 256-byte limit"
+    );
 
     Ok(())
 }

--- a/crates/hotblocks/tests/transaction_hash_index.rs
+++ b/crates/hotblocks/tests/transaction_hash_index.rs
@@ -1,0 +1,177 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde_json::Value;
+use sqd_hotblocks_harness::{
+    chain::{Chain, Evm},
+    compare::expected_transactions,
+    driver::Client,
+    harness::{Harness, HarnessConfig},
+    types::{Block, BlockNumber, TransactionRef, block_hash}
+};
+
+const START: u64 = 1_000;
+const REINCLUDED_HASH: &str = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn transaction_lookup_resolves_ingested_transactions_and_misses_unknown_hashes() -> Result<()> {
+    let mut harness = start_harness(Arc::new(Evm)).await?;
+
+    harness.produce(20)?;
+    settle_or_panic(&harness).await;
+    harness.assert_transaction_hash_index_conforms().await?;
+
+    assert_eq!(
+        harness
+            .client
+            .transaction_by_hash(&block_hash(START + 10_000, 99))
+            .await?,
+        None
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn transaction_lookup_removes_the_replaced_branch_after_a_reorg() -> Result<()> {
+    let mut harness = start_harness(Arc::new(Evm)).await?;
+    harness.produce(20)?;
+    settle_or_panic(&harness).await;
+
+    let fork_from = START + 10;
+    let stale_hashes: Vec<String> = harness
+        .model
+        .seg
+        .iter()
+        .filter(|block| block.number >= fork_from)
+        .flat_map(|block| expected_transactions(&*harness.chain, block).unwrap())
+        .map(|transaction| transaction.hash)
+        .collect();
+
+    harness.fork(fork_from, 10)?;
+    settle_or_panic(&harness).await;
+    harness.assert_transaction_hash_index_conforms().await?;
+
+    for hash in stale_hashes {
+        assert_eq!(
+            harness.client.transaction_by_hash(&hash).await?,
+            None,
+            "a transaction from the replaced branch must stop resolving"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reorg_reinclusion_resolves_to_the_new_block_and_index() -> Result<()> {
+    let mut harness = start_harness(Arc::new(ReinclusionEvm)).await?;
+    harness.produce(20)?;
+    settle_or_panic(&harness).await;
+
+    assert_eq!(
+        harness.client.transaction_by_hash(REINCLUDED_HASH).await?,
+        Some(TransactionRef::new(START + 11, 0, REINCLUDED_HASH))
+    );
+
+    harness.fork(START + 10, 10)?;
+    harness.settle().await?;
+    harness.assert_transaction_hash_index_conforms().await?;
+
+    assert_eq!(
+        harness.client.transaction_by_hash(REINCLUDED_HASH).await?,
+        Some(TransactionRef::new(START + 13, 0, REINCLUDED_HASH)),
+        "INV-47 requires old-branch removals to happen before new-branch insertion"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn disabled_index_misses_and_malformed_hashes_are_rejected_before_storage() -> Result<()> {
+    let config = HarnessConfig::from_block(env!("CARGO_BIN_EXE_sqd-hotblocks"), Arc::new(Evm), START);
+    let mut harness = Harness::start(config).await?;
+    harness.produce(20)?;
+    settle_or_panic(&harness).await;
+
+    let indexed_while_disabled = harness
+        .model
+        .seg
+        .iter()
+        .flat_map(|block| expected_transactions(&*harness.chain, block).unwrap())
+        .next()
+        .expect("the EVM fixture should emit at least one transaction");
+    assert_eq!(
+        harness.client.transaction_by_hash(&indexed_while_disabled.hash).await?,
+        None,
+        "a disabled index must behave like an empty index"
+    );
+
+    assert_eq!(
+        harness.client.transaction_by_hash_status(&"é".repeat(256)).await?,
+        400,
+        "P-HASH-MAXLEN counts UTF-8 bytes"
+    );
+
+    let unknown_dataset = Client::new(harness.sut.base_url(), "unknown-dataset")?;
+    assert_eq!(
+        unknown_dataset.transaction_by_hash_status(&"x".repeat(257)).await?,
+        400,
+        "an oversized hash must be rejected before dataset/storage lookup"
+    );
+    Ok(())
+}
+
+async fn start_harness(chain: Arc<dyn Chain>) -> Result<Harness> {
+    let mut config = HarnessConfig::from_block(env!("CARGO_BIN_EXE_sqd-hotblocks"), chain, START);
+    config.sut_args.push("--transaction-hash-index".into());
+    Harness::start(config).await
+}
+
+async fn settle_or_panic(harness: &Harness) {
+    if let Err(err) = harness.settle().await {
+        panic!("transaction-index harness failed to settle: {err:?}");
+    }
+}
+
+/// Re-includes one transaction from block 1011 at block 1013 on the first
+/// replacement branch. The normal EVM generator makes hashes branch-specific,
+/// so this focused chain variant exercises the ordering hazard in INV-47.
+struct ReinclusionEvm;
+
+impl Chain for ReinclusionEvm {
+    fn config_kind(&self) -> &'static str {
+        Evm.config_kind()
+    }
+
+    fn storage_kind(&self) -> &'static str {
+        Evm.storage_kind()
+    }
+
+    fn dialect(&self) -> &'static str {
+        Evm.dialect()
+    }
+
+    fn source_block(&self, block: &Block) -> Value {
+        rewrite_reincluded_transaction(block, Evm.source_block(block))
+    }
+
+    fn scan_query(&self, from: BlockNumber, to: Option<BlockNumber>, expected_parent: Option<&str>) -> Value {
+        Evm.scan_query(from, to, expected_parent)
+    }
+
+    fn expected_emission(&self, block: &Block) -> Value {
+        rewrite_reincluded_transaction(block, Evm.expected_emission(block))
+    }
+}
+
+fn rewrite_reincluded_transaction(block: &Block, mut value: Value) -> Value {
+    let is_old_position = block.fork_id == 0 && block.number == START + 11;
+    let is_new_position = block.fork_id == 1 && block.number == START + 13;
+    if is_old_position || is_new_position {
+        let transaction = value
+            .get_mut("transactions")
+            .and_then(Value::as_array_mut)
+            .and_then(|transactions| transactions.first_mut())
+            .expect("both selected odd-numbered blocks carry one transaction");
+        transaction["hash"] = Value::String(REINCLUDED_HASH.to_owned());
+    }
+    value
+}

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -16,6 +16,18 @@ pub struct BlockRef {
     pub hash: String
 }
 
+/// Position of a transaction in the canonical chain.
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "valuable", derive(valuable::Valuable))]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct TransactionRef {
+    pub block_number: BlockNumber,
+    pub transaction_index: ItemIndex,
+    pub hash: String
+}
+
 impl BlockRef {
     pub fn set_hash(&mut self, hash: &str) {
         self.hash.clear();

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -16,9 +16,14 @@ sqd-array = { path = "../array" }
 sqd-primitives = { path = "../primitives", features = ["borsh", "sid", "range"] }
 
 [dev-dependencies]
+criterion = "0.5.1"
 proptest = { workspace = true }
 tempfile = { workspace = true }
 rand = "0.9.0"
+
+[[bench]]
+name = "transaction_hash_index"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/storage/benches/transaction_hash_index.rs
+++ b/crates/storage/benches/transaction_hash_index.rs
@@ -1,0 +1,139 @@
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use arrow::{
+    array::{ArrayRef, RecordBatch, StringArray, UInt32Array, UInt64Array},
+    datatypes::{DataType, Field, Schema}
+};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use sqd_storage::db::{Chunk, Database, DatabaseSettings, DatasetId, DatasetKind};
+use tempfile::TempDir;
+
+struct Fixture {
+    // Field order is intentional: close RocksDB before TempDir removes its files.
+    db: Database,
+    chunk: Chunk,
+    dataset_id: DatasetId,
+    _dir: TempDir
+}
+
+fn transaction_hash(index: usize) -> String {
+    format!("0x{index:064x}")
+}
+
+fn fixture(transaction_count: usize, index_enabled: bool) -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let db = DatabaseSettings::default()
+        .with_transaction_hash_index(index_enabled)
+        .open(dir.path())
+        .unwrap();
+    let dataset_id = DatasetId::from_str("benchmark");
+    db.create_dataset(dataset_id, DatasetKind::from_str("evm")).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("block_number", DataType::UInt64, false),
+        Field::new("transaction_index", DataType::UInt32, false),
+        Field::new("hash", DataType::Utf8, false),
+    ]));
+    let block_numbers = Arc::new(UInt64Array::from(
+        (0..transaction_count)
+            .map(|index| (index / 100) as u64)
+            .collect::<Vec<_>>()
+    )) as ArrayRef;
+    let transaction_indexes = Arc::new(UInt32Array::from(
+        (0..transaction_count)
+            .map(|index| (index % 100) as u32)
+            .collect::<Vec<_>>()
+    )) as ArrayRef;
+    let hashes = (0..transaction_count).map(transaction_hash).collect::<Vec<_>>();
+    let hashes = Arc::new(StringArray::from(hashes.iter().map(String::as_str).collect::<Vec<_>>())) as ArrayRef;
+
+    let mut builder = db.new_table_builder(schema.clone());
+    builder
+        .write_record_batch(&RecordBatch::try_new(schema, vec![block_numbers, transaction_indexes, hashes]).unwrap())
+        .unwrap();
+    let mut tables = BTreeMap::new();
+    tables.insert("transactions".to_owned(), builder.finish().unwrap());
+    let last_block = transaction_count.saturating_sub(1) as u64 / 100;
+    let chunk = Chunk::V1 {
+        first_block: 0,
+        last_block,
+        last_block_hash: format!("block-{last_block}"),
+        parent_block_hash: "base".to_owned(),
+        first_block_time: None,
+        last_block_time: None,
+        tables
+    };
+
+    Fixture {
+        db,
+        chunk,
+        dataset_id,
+        _dir: dir
+    }
+}
+
+fn ingest_benchmark(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("transaction_hash_index/ingest");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(5));
+
+    for transaction_count in [1_000, 10_000] {
+        group.throughput(Throughput::Elements(transaction_count as u64));
+        for enabled in [false, true] {
+            let variant = if enabled { "enabled" } else { "disabled" };
+            group.bench_with_input(
+                BenchmarkId::new(variant, transaction_count),
+                &transaction_count,
+                |bencher, &transaction_count| {
+                    bencher.iter_batched(
+                        || fixture(transaction_count, enabled),
+                        |fixture| {
+                            fixture.db.insert_chunk(fixture.dataset_id, &fixture.chunk).unwrap();
+                            fixture
+                        },
+                        BatchSize::LargeInput
+                    );
+                }
+            );
+        }
+    }
+    group.finish();
+}
+
+fn lookup_benchmark(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("transaction_hash_index/lookup");
+
+    for transaction_count in [1_000, 100_000] {
+        let fixture = fixture(transaction_count, true);
+        fixture.db.insert_chunk(fixture.dataset_id, &fixture.chunk).unwrap();
+        let hit = transaction_hash(transaction_count - 1);
+        let miss = transaction_hash(transaction_count + 1);
+
+        group.bench_function(BenchmarkId::new("hit", transaction_count), |bencher| {
+            bencher.iter(|| {
+                criterion::black_box(
+                    fixture
+                        .db
+                        .snapshot()
+                        .find_transaction_by_hash(fixture.dataset_id, criterion::black_box(&hit))
+                        .unwrap()
+                )
+            });
+        });
+        group.bench_function(BenchmarkId::new("miss", transaction_count), |bencher| {
+            bencher.iter(|| {
+                criterion::black_box(
+                    fixture
+                        .db
+                        .snapshot()
+                        .find_transaction_by_hash(fixture.dataset_id, criterion::black_box(&miss))
+                        .unwrap()
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, ingest_benchmark, lookup_benchmark);
+criterion_main!(benches);

--- a/crates/storage/src/db/data.rs
+++ b/crates/storage/src/db/data.rs
@@ -99,19 +99,25 @@ impl Display for ChunkId {
     }
 }
 
-/// Key for the `hash -> block number` index in `CF_BLOCK_HASHES`:
+/// Key shared by the hash-index column families:
 /// `dataset_id (48 bytes) || hash UTF-8 bytes`, the hash exactly as it appears
 /// in the Arrow `hash` column (no normalization).
-pub(crate) struct BlockHashIndexKey {
+pub(crate) struct HashIndexKey {
     bytes: Vec<u8>
 }
 
-impl BlockHashIndexKey {
+impl HashIndexKey {
     pub fn new(dataset_id: DatasetId, hash: &str) -> Self {
         let mut bytes = Vec::with_capacity(48 + hash.len());
         bytes.extend_from_slice(dataset_id.as_ref());
         bytes.extend_from_slice(hash.as_bytes());
         Self { bytes }
+    }
+
+    /// Reuses the key allocation while streaming a table into a RocksDB write batch.
+    pub fn set_hash(&mut self, hash: &str) {
+        self.bytes.truncate(48);
+        self.bytes.extend_from_slice(hash.as_bytes());
     }
 
     /// The `[start, end)` key range covering every entry of `dataset_id`.
@@ -122,7 +128,7 @@ impl BlockHashIndexKey {
     }
 }
 
-impl AsRef<[u8]> for BlockHashIndexKey {
+impl AsRef<[u8]> for HashIndexKey {
     fn as_ref(&self) -> &[u8] {
         &self.bytes
     }

--- a/crates/storage/src/db/db.rs
+++ b/crates/storage/src/db/db.rs
@@ -2,17 +2,22 @@ use std::path::Path;
 
 use anyhow::ensure;
 use arrow::datatypes::SchemaRef;
+use parking_lot::Mutex;
 use rocksdb::{ColumnFamilyDescriptor, Options as RocksOptions};
 use sqd_primitives::Name;
 
 use super::{
-    data::{BlockHashIndexKey, Dataset, DatasetId, DatasetKind, DatasetLabel},
+    data::{Dataset, DatasetId, DatasetKind, DatasetLabel, HashIndexKey},
     read::snapshot::ReadSnapshot
 };
 use crate::db::{
     ops::{perform_dataset_compaction, CompactionStatus},
     read::datasets::list_all_datasets,
-    write::{ops as cleanup_ops, table_builder::TableBuilder, tx::Tx},
+    write::{
+        ops as cleanup_ops,
+        table_builder::TableBuilder,
+        tx::{HashIndexWriteMetrics, Tx}
+    },
     Chunk, DatasetUpdate
 };
 
@@ -23,6 +28,7 @@ pub const CF_TABLES: Name = "TABLES";
 pub const CF_DIRTY_TABLES: Name = "DIRTY_TABLES";
 pub const CF_DELETED_TABLES: Name = "DELETED_TABLES";
 pub const CF_BLOCK_HASHES: Name = "BLOCK_HASHES";
+pub const CF_TRANSACTION_HASHES: Name = "TRANSACTION_HASHES";
 
 /// Whole-file rewrite cadence for `CF_TABLES`. RocksDB leaves `periodic_compaction_seconds`
 /// disabled for leveled compaction without a compaction filter, so the effective baseline
@@ -47,7 +53,8 @@ pub struct DatabaseSettings {
     auto_compactions: bool,
     max_background_jobs: usize,
     periodic_compaction_secs: u64,
-    block_hash_index: bool
+    block_hash_index: bool,
+    transaction_hash_index: bool
 }
 
 /// RocksDB's default of 2 could not keep up with ingest during the NET-819 incident, but a
@@ -72,7 +79,8 @@ impl Default for DatabaseSettings {
             auto_compactions: true,
             max_background_jobs: default_max_background_jobs(),
             periodic_compaction_secs: DEFAULT_PERIODIC_COMPACTION_SECS,
-            block_hash_index: false
+            block_hash_index: false,
+            transaction_hash_index: false
         }
     }
 }
@@ -142,6 +150,14 @@ impl DatabaseSettings {
     /// their chunk is pruned, so the index drains after the flag goes off.
     pub fn with_block_hash_index(mut self, yes: bool) -> Self {
         self.block_hash_index = yes;
+        self
+    }
+
+    /// Whether newly ingested chunks get their transaction hashes indexed in
+    /// `CF_TRANSACTION_HASHES`. Independent of block-hash indexing because the
+    /// transaction index is commonly orders of magnitude larger.
+    pub fn with_transaction_hash_index(mut self, yes: bool) -> Self {
+        self.transaction_hash_index = yes;
         self
     }
 
@@ -224,7 +240,47 @@ impl DatabaseSettings {
         options
     }
 
+    /// Point-lookup indexes use full Bloom filters to make misses cheap.
+    /// Retention produces dense runs of tombstones, so the same bounded
+    /// deletion/periodic-compaction policy used for table data keeps index
+    /// space converging in the background.
+    fn hash_index_cf_options(&self, compression: rocksdb::DBCompressionType) -> RocksOptions {
+        let mut block_based_table_factory = rocksdb::BlockBasedOptions::default();
+        block_based_table_factory.set_cache_index_and_filter_blocks(self.cache_index_and_filter_blocks);
+        block_based_table_factory.set_bloom_filter(10.0, false);
+        block_based_table_factory.set_optimize_filters_for_memory(true);
+
+        let mut options = RocksOptions::default();
+        options.set_block_based_table_factory(&block_based_table_factory);
+        options.set_compression_type(compression);
+        options.add_compact_on_deletion_collector_factory(128 * 1024, 64 * 1024, 0.5);
+        if self.periodic_compaction_secs > 0 {
+            options.set_periodic_compaction_seconds(self.periodic_compaction_secs);
+        }
+        options.set_level_compaction_dynamic_level_bytes(true);
+        if !self.auto_compactions {
+            options.set_disable_auto_compactions(true);
+        }
+        options
+    }
+
     pub fn open(&self, path: impl AsRef<Path>) -> anyhow::Result<Database> {
+        // Keep the established block index on Snappy: the A/B sizing probe
+        // found less than 0.5% difference, which does not justify rewriting
+        // existing SSTs. The new transaction index uses LZ4 like table data.
+        self.open_with_hash_index_compressions(
+            path,
+            rocksdb::DBCompressionType::Snappy,
+            rocksdb::DBCompressionType::Lz4
+        )
+    }
+
+    fn open_with_hash_index_compressions(
+        &self,
+        path: impl AsRef<Path>,
+        block_hash_compression: rocksdb::DBCompressionType,
+        transaction_hash_compression: rocksdb::DBCompressionType
+    ) -> anyhow::Result<Database> {
         let options = self.db_options();
 
         let db = RocksDB::open_cf_descriptors(
@@ -236,14 +292,20 @@ impl DatabaseSettings {
                 ColumnFamilyDescriptor::new(CF_TABLES, self.tables_cf_options()),
                 ColumnFamilyDescriptor::new(CF_DIRTY_TABLES, self.cf_default_options()),
                 ColumnFamilyDescriptor::new(CF_DELETED_TABLES, self.cf_default_options()),
-                ColumnFamilyDescriptor::new(CF_BLOCK_HASHES, self.cf_default_options())
+                ColumnFamilyDescriptor::new(CF_BLOCK_HASHES, self.hash_index_cf_options(block_hash_compression)),
+                ColumnFamilyDescriptor::new(
+                    CF_TRANSACTION_HASHES,
+                    self.hash_index_cf_options(transaction_hash_compression)
+                )
             ]
         )?;
 
         Ok(Database {
             db,
             options,
-            block_hash_index: self.block_hash_index
+            block_hash_index: self.block_hash_index,
+            transaction_hash_index: self.transaction_hash_index,
+            lifecycle_lock: Mutex::new(())
         })
     }
 }
@@ -251,11 +313,18 @@ impl DatabaseSettings {
 pub struct Database {
     db: RocksDB,
     options: RocksOptions,
-    block_hash_index: bool
+    block_hash_index: bool,
+    transaction_hash_index: bool,
+    /// Serializes only CREATE/DROP so a dataset ID cannot be reused before a
+    /// prior incarnation's derived-index prefixes have been physically purged.
+    lifecycle_lock: Mutex<()>
 }
 
 impl Database {
     pub fn create_dataset(&self, id: DatasetId, kind: DatasetKind) -> anyhow::Result<()> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
+        self.purge_stale_hash_indexes_if_dataset_absent(id)?;
+
         Tx::new(&self.db).run(|tx| {
             let label = tx.find_label_for_update(id)?;
             ensure!(label.is_none(), "dataset {} already exists", id);
@@ -271,6 +340,9 @@ impl Database {
     }
 
     pub fn create_dataset_if_not_exists(&self, id: DatasetId, kind: DatasetKind) -> anyhow::Result<()> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
+        self.purge_stale_hash_indexes_if_dataset_absent(id)?;
+
         Tx::new(&self.db).run(|tx| {
             if let Some(label) = tx.find_label_for_update(id)? {
                 ensure!(
@@ -306,13 +378,30 @@ impl Database {
         self.update_dataset(dataset_id, |tx| tx.insert_fork(chunk))
     }
 
-    pub fn update_dataset<F, R>(&self, dataset_id: DatasetId, mut cb: F) -> anyhow::Result<R>
+    pub fn update_dataset<F, R>(&self, dataset_id: DatasetId, cb: F) -> anyhow::Result<R>
+    where
+        F: FnMut(&mut DatasetUpdate<'_>) -> anyhow::Result<R>
+    {
+        let mut metrics = HashIndexWriteMetrics::default();
+        self.update_dataset_with_hash_index_metrics(dataset_id, &mut metrics, cb)
+    }
+
+    /// Runs a dataset update and returns aggregate block/transaction hash-index
+    /// staging time through `metrics`. Work repeated by optimistic transaction
+    /// retries is included.
+    pub fn update_dataset_with_hash_index_metrics<F, R>(
+        &self,
+        dataset_id: DatasetId,
+        metrics: &mut HashIndexWriteMetrics,
+        mut cb: F
+    ) -> anyhow::Result<R>
     where
         F: FnMut(&mut DatasetUpdate<'_>) -> anyhow::Result<R>
     {
         Tx::new(&self.db)
             .with_block_hash_index(self.block_hash_index)
-            .run(|tx| {
+            .with_transaction_hash_index(self.transaction_hash_index)
+            .run_with_hash_index_metrics(metrics, |tx| {
                 let mut upd = DatasetUpdate::new(tx, dataset_id)?;
                 let result = cb(&mut upd)?;
                 upd.finish()?;
@@ -346,10 +435,11 @@ impl Database {
     }
 
     pub fn delete_dataset(&self, dataset_id: DatasetId) -> anyhow::Result<()> {
-        self.purge_block_hash_index(dataset_id)?;
+        let _lifecycle_guard = self.lifecycle_lock.lock();
 
-        // Metadata is removed atomically in one transaction, so the dataset is
-        // never observed half-deleted.
+        // Metadata is removed atomically first. Hash lookups check the label in
+        // their snapshot, so the logical indexes disappear in this same commit;
+        // bounded physical cleanup below cannot expose stale hits.
         Tx::new(&self.db).run(|tx| {
             if tx.find_label_for_update(dataset_id)?.is_none() {
                 return Ok(());
@@ -361,19 +451,37 @@ impl Database {
             tx.delete_label(dataset_id)
         })?;
 
+        // The logical DROP has committed. Errors below mean physical cleanup
+        // is incomplete, not that the dataset is still visible; retry is safe.
+        self.purge_hash_indexes(dataset_id)?;
         self.cleanup()?;
         Ok(())
     }
 
-    /// Point-deletes every `CF_BLOCK_HASHES` entry of `dataset_id` in bounded
-    /// batches (`delete_range` is not supported on `OptimisticTransactionDB`).
-    /// Runs outside the metadata transaction: a crash in between leaves chunks
-    /// without index entries (hashes 404), not corruption.
-    fn purge_block_hash_index(&self, dataset_id: DatasetId) -> anyhow::Result<()> {
+    /// A crash after DROP's logical commit may leave physical index keys. An
+    /// absent dataset must purge those keys before publishing a new label for
+    /// the same ID, or a later incarnation could inherit stale entries.
+    fn purge_stale_hash_indexes_if_dataset_absent(&self, dataset_id: DatasetId) -> anyhow::Result<()> {
+        if !self.snapshot().has_dataset(dataset_id)? {
+            self.purge_hash_indexes(dataset_id)?;
+        }
+        Ok(())
+    }
+
+    fn purge_hash_indexes(&self, dataset_id: DatasetId) -> anyhow::Result<()> {
+        self.purge_hash_index(CF_BLOCK_HASHES, dataset_id)?;
+        self.purge_hash_index(CF_TRANSACTION_HASHES, dataset_id)
+    }
+
+    /// Point-deletes every hash-index entry of `dataset_id` in bounded batches
+    /// (`delete_range` is not supported on an optimistic transaction).
+    /// Runs after logical DROP; the absent dataset label makes these physical
+    /// entries invisible to hash lookups while cleanup proceeds.
+    fn purge_hash_index(&self, cf_name: Name, dataset_id: DatasetId) -> anyhow::Result<()> {
         const BATCH_SIZE: usize = 10_000;
 
-        let cf = self.db.cf_handle(CF_BLOCK_HASHES).unwrap();
-        let (start, end) = BlockHashIndexKey::dataset_range(dataset_id);
+        let cf = self.db.cf_handle(cf_name).unwrap();
+        let (start, end) = HashIndexKey::dataset_range(dataset_id);
 
         let mut read_opts = rocksdb::ReadOptions::default();
         read_opts.set_iterate_upper_bound(end);
@@ -462,5 +570,185 @@ impl Database {
 impl std::fmt::Debug for Database {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Database").field("path", &self.db.path()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write as _;
+
+    use super::*;
+
+    fn realistic_hash(sequence: u64) -> String {
+        let mut state = sequence;
+        let mut hash = String::with_capacity(66);
+        hash.push_str("0x");
+        for _ in 0..4 {
+            state = state.wrapping_add(0x9e3779b97f4a7c15);
+            let mut word = state;
+            word = (word ^ (word >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+            word = (word ^ (word >> 27)).wrapping_mul(0x94d049bb133111eb);
+            word ^= word >> 31;
+            write!(hash, "{word:016x}").unwrap();
+        }
+        hash
+    }
+
+    fn transaction_position(sequence: u64) -> [u8; 12] {
+        const TRANSACTIONS_PER_BLOCK: u64 = 100;
+
+        let block_number = sequence / TRANSACTIONS_PER_BLOCK;
+        let transaction_index = u32::try_from(sequence % TRANSACTIONS_PER_BLOCK).unwrap();
+        let mut bytes = [0; 12];
+        bytes[..8].copy_from_slice(&block_number.to_be_bytes());
+        bytes[8..].copy_from_slice(&transaction_index.to_be_bytes());
+        bytes
+    }
+
+    fn write_hash_index_entries(db: &Database, dataset_id: DatasetId, first: u64, end: u64) {
+        const WRITE_BATCH_SIZE: u64 = 10_000;
+
+        let block_cf = db.db.cf_handle(CF_BLOCK_HASHES).unwrap();
+        let transaction_cf = db.db.cf_handle(CF_TRANSACTION_HASHES).unwrap();
+        let mut batch_first = first;
+        while batch_first < end {
+            let batch_end = batch_first.saturating_add(WRITE_BATCH_SIZE).min(end);
+            let mut batch = RocksWriteBatch::default();
+            let mut key = HashIndexKey::new(dataset_id, "");
+            for sequence in batch_first..batch_end {
+                key.set_hash(&realistic_hash(sequence));
+                batch.put_cf(block_cf, &key, sequence.to_be_bytes());
+                batch.put_cf(transaction_cf, &key, transaction_position(sequence));
+            }
+            db.db.write(batch).unwrap();
+            batch_first = batch_end;
+        }
+    }
+
+    fn flush_and_compact_hash_indexes(db: &Database) {
+        for cf_name in [CF_BLOCK_HASHES, CF_TRANSACTION_HASHES] {
+            let cf = db.db.cf_handle(cf_name).unwrap();
+            db.db.flush_cf(cf).unwrap();
+            db.db.compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
+        }
+    }
+
+    fn print_hash_index_size(db: &Database, codec: &str, cf_name: &str, index: &str, entries: u64) {
+        let live_sst_bytes = db
+            .get_int_property(cf_name, "rocksdb.live-sst-files-size")
+            .unwrap()
+            .unwrap();
+        let bytes_per_entry =
+            f64::from(u32::try_from(live_sst_bytes).unwrap()) / f64::from(u32::try_from(entries).unwrap());
+        let gib_per_billion = bytes_per_entry * 1_000_000_000.0 / 1024.0_f64.powi(3);
+
+        eprintln!(
+            "hash_index_compression_size codec={codec} index={index} entries={entries} live_sst_bytes={live_sst_bytes} bytes_per_entry={bytes_per_entry:.2} gib_per_billion={gib_per_billion:.2}"
+        );
+    }
+
+    fn measure_hash_index_compression(compression: rocksdb::DBCompressionType, codec: &str) {
+        const TARGETS: [u64; 2] = [100_000, 1_000_000];
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = DatabaseSettings::default()
+            .with_auto_compactions(false)
+            .with_periodic_compaction_secs(0)
+            .open_with_hash_index_compressions(dir.path(), compression, compression)
+            .unwrap();
+        let dataset_id = DatasetId::from_str("compression-measurement");
+        let mut indexed_entries = 0;
+
+        for target in TARGETS {
+            write_hash_index_entries(&db, dataset_id, indexed_entries, target);
+            indexed_entries = target;
+            flush_and_compact_hash_indexes(&db);
+            print_hash_index_size(&db, codec, CF_BLOCK_HASHES, "block", indexed_entries);
+            print_hash_index_size(&db, codec, CF_TRANSACTION_HASHES, "transaction", indexed_entries);
+        }
+    }
+
+    /// Compares compressed SST footprint with identical random-looking hashes,
+    /// production key/value encodings, Bloom filters and full compaction. WAL,
+    /// memtables and table data are deliberately outside the measurement.
+    ///
+    /// Run with:
+    /// `cargo test -p sqd-storage --release --lib measure_hash_index_compression_disk_size -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual Snappy/LZ4 hash-index disk footprint measurement"]
+    fn measure_hash_index_compression_disk_size() {
+        measure_hash_index_compression(rocksdb::DBCompressionType::Snappy, "snappy");
+        measure_hash_index_compression(rocksdb::DBCompressionType::Lz4, "lz4");
+    }
+
+    #[test]
+    fn create_purges_crash_residue_before_publishing_the_dataset_label() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DatabaseSettings::default().open(dir.path()).unwrap();
+        let dataset_id = DatasetId::from_str("reused-dataset");
+        let hash = "0xstale";
+        let key = HashIndexKey::new(dataset_id, hash);
+
+        db.db
+            .put_cf(db.db.cf_handle(CF_BLOCK_HASHES).unwrap(), &key, [0; 8])
+            .unwrap();
+        db.db
+            .put_cf(db.db.cf_handle(CF_TRANSACTION_HASHES).unwrap(), &key, [0; 12])
+            .unwrap();
+
+        // A crash after DROP may leave these physical keys, but an absent label
+        // keeps them out of the logical indexes.
+        assert_eq!(db.snapshot().find_block_by_hash(dataset_id, hash).unwrap(), None);
+        assert_eq!(db.snapshot().find_transaction_by_hash(dataset_id, hash).unwrap(), None);
+
+        db.create_dataset(dataset_id, DatasetKind::from_str("evm")).unwrap();
+
+        // CREATE must purge the old incarnation before making the label visible.
+        assert_eq!(db.snapshot().find_block_by_hash(dataset_id, hash).unwrap(), None);
+        assert_eq!(db.snapshot().find_transaction_by_hash(dataset_id, hash).unwrap(), None);
+    }
+
+    #[test]
+    fn hash_lookup_presence_gate_does_not_deserialize_the_dataset_label() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DatabaseSettings::default().open(dir.path()).unwrap();
+        let dataset_id = DatasetId::from_str("raw-label-gate");
+        let hash = "0xindexed";
+        let key = HashIndexKey::new(dataset_id, hash);
+        let block_number = 42_u64;
+        let transaction_index = 7_u32;
+        let mut transaction_position = [0; 12];
+        transaction_position[..8].copy_from_slice(&block_number.to_be_bytes());
+        transaction_position[8..].copy_from_slice(&transaction_index.to_be_bytes());
+
+        db.db
+            .put_cf(db.db.cf_handle(CF_DATASETS).unwrap(), dataset_id, [u8::MAX])
+            .unwrap();
+        db.db
+            .put_cf(
+                db.db.cf_handle(CF_BLOCK_HASHES).unwrap(),
+                &key,
+                block_number.to_be_bytes()
+            )
+            .unwrap();
+        db.db
+            .put_cf(
+                db.db.cf_handle(CF_TRANSACTION_HASHES).unwrap(),
+                &key,
+                transaction_position
+            )
+            .unwrap();
+
+        let snapshot = db.snapshot();
+        assert!(snapshot.get_label(dataset_id).is_err());
+
+        let block = snapshot.find_block_by_hash(dataset_id, hash).unwrap().unwrap();
+        assert_eq!(block.number, block_number);
+        assert_eq!(block.hash, hash);
+
+        let transaction = snapshot.find_transaction_by_hash(dataset_id, hash).unwrap().unwrap();
+        assert_eq!(transaction.block_number, block_number);
+        assert_eq!(transaction.transaction_index, transaction_index);
+        assert_eq!(transaction.hash, hash);
     }
 }

--- a/crates/storage/src/db/mod.rs
+++ b/crates/storage/src/db/mod.rs
@@ -15,5 +15,5 @@ pub use table_id::TableId;
 pub use write::{
     dataset_update::*,
     table_builder::*,
-    tx::{get_global_tx_restarts, get_local_tx_restarts}
+    tx::{get_global_tx_restarts, get_local_tx_restarts, HashIndexWriteMetrics}
 };

--- a/crates/storage/src/db/read/blocks_table.rs
+++ b/crates/storage/src/db/read/blocks_table.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, ensure};
 use arrow::{
     array::{Array, AsArray},
     datatypes::{DataType, UInt32Type, UInt64Type}
@@ -57,8 +57,9 @@ fn find_block_row<BN: Copy + Ord>(numbers: &[BN], block: BN) -> Option<usize> {
 
 /// Streams all `(block number, hash)` pairs of a `blocks` table, reading the
 /// columns in batches so peak memory stays `O(batch)` even for large compacted
-/// chunks. `number` must be `UInt32`/`UInt64` and `hash` must be `Utf8`;
-/// anything else is a hard error rather than silently indexed garbage.
+/// chunks. `number` must be `UInt32`/`UInt64`, `hash` must be `Utf8`, and both
+/// columns must be non-null; anything else is a hard error rather than
+/// silently indexing incomplete data.
 pub fn for_each_block_hash<S: KvRead + Sync>(
     blocks_table: &TableReader<S>,
     mut visit: impl FnMut(BlockNumber, &str) -> anyhow::Result<()>
@@ -99,6 +100,11 @@ pub fn for_each_block_hash<S: KvRead + Sync>(
             hash_reader.read_slice(&mut builder, offset, len)?;
             builder.finish()
         };
+
+        ensure!(
+            numbers.null_count() == 0 && hashes.null_count() == 0,
+            "block number and hash columns must not contain nulls"
+        );
         let hashes = hashes.as_string::<i32>();
 
         match numbers.data_type() {

--- a/crates/storage/src/db/read/mod.rs
+++ b/crates/storage/src/db/read/mod.rs
@@ -2,3 +2,4 @@ pub mod blocks_table;
 pub mod chunk;
 pub mod datasets;
 pub mod snapshot;
+pub mod transactions_table;

--- a/crates/storage/src/db/read/snapshot.rs
+++ b/crates/storage/src/db/read/snapshot.rs
@@ -3,12 +3,15 @@ use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 use anyhow::{anyhow, Context};
 use parking_lot::Mutex;
 use rocksdb::{ColumnFamily, ReadOptions};
-use sqd_primitives::{BlockNumber, BlockRef, Name};
+use sqd_primitives::{BlockNumber, BlockRef, Name, TransactionRef};
 
 use crate::{
     db::{
-        data::{BlockHashIndexKey, Chunk, DatasetId},
-        db::{RocksDB, RocksIterator, RocksSnapshot, CF_BLOCK_HASHES, CF_CHUNKS, CF_DATASETS, CF_TABLES},
+        data::{Chunk, DatasetId, HashIndexKey},
+        db::{
+            RocksDB, RocksIterator, RocksSnapshot, CF_BLOCK_HASHES, CF_CHUNKS, CF_DATASETS, CF_TABLES,
+            CF_TRANSACTION_HASHES
+        },
         read::chunk::ChunkIterator,
         table_id::TableId,
         DatasetLabel
@@ -40,6 +43,13 @@ impl<'a> ReadSnapshot<'a> {
         } else {
             None
         })
+    }
+
+    pub(crate) fn has_dataset(&self, dataset_id: DatasetId) -> anyhow::Result<bool> {
+        Ok(self
+            .db
+            .get_pinned_cf_opt(self.cf_handle(CF_DATASETS), dataset_id, &self.new_options())?
+            .is_some())
     }
 
     pub fn create_table_reader(&self, table_id: TableId) -> anyhow::Result<SnapshotTableReader<'_>> {
@@ -78,7 +88,13 @@ impl<'a> ReadSnapshot<'a> {
     /// Resolves a block hash via the `CF_BLOCK_HASHES` index. `Ok(None)` means
     /// the hash is not indexed (unknown, pre-index chunk, or non-indexed kind).
     pub fn find_block_by_hash(&self, dataset_id: DatasetId, hash: &str) -> anyhow::Result<Option<BlockRef>> {
-        let key = BlockHashIndexKey::new(dataset_id, hash);
+        // DROP removes the label before bounded physical index cleanup. Checking
+        // it in this same snapshot makes the logical index transition atomic.
+        if !self.has_dataset(dataset_id)? {
+            return Ok(None);
+        }
+
+        let key = HashIndexKey::new(dataset_id, hash);
         let Some(bytes) = self
             .db
             .get_pinned_cf_opt(self.cf_handle(CF_BLOCK_HASHES), &key, &self.new_options())?
@@ -92,6 +108,46 @@ impl<'a> ReadSnapshot<'a> {
             .context("CF_BLOCK_HASHES value has unexpected length, expected 8 bytes")?;
         Ok(Some(BlockRef {
             number: BlockNumber::from_be_bytes(arr),
+            hash: hash.to_string()
+        }))
+    }
+
+    /// Resolves a transaction hash via `CF_TRANSACTION_HASHES`. `Ok(None)`
+    /// means the hash is not indexed, which is deliberately not proof that the
+    /// transaction is absent from the retained window.
+    pub fn find_transaction_by_hash(
+        &self,
+        dataset_id: DatasetId,
+        hash: &str
+    ) -> anyhow::Result<Option<TransactionRef>> {
+        const VALUE_LEN: usize = 12;
+
+        // See `find_block_by_hash`: stale physical keys after DROP are never
+        // observable, and CREATE purges them before reusing a dataset ID.
+        if !self.has_dataset(dataset_id)? {
+            return Ok(None);
+        }
+
+        let key = HashIndexKey::new(dataset_id, hash);
+        let Some(bytes) =
+            self.db
+                .get_pinned_cf_opt(self.cf_handle(CF_TRANSACTION_HASHES), &key, &self.new_options())?
+        else {
+            return Ok(None);
+        };
+
+        let bytes: &[u8; VALUE_LEN] = bytes
+            .as_ref()
+            .try_into()
+            .context("CF_TRANSACTION_HASHES value has unexpected length, expected 12 bytes")?;
+        let mut block_number_bytes = [0; 8];
+        block_number_bytes.copy_from_slice(&bytes[..8]);
+        let mut transaction_index_bytes = [0; 4];
+        transaction_index_bytes.copy_from_slice(&bytes[8..]);
+
+        Ok(Some(TransactionRef {
+            block_number: BlockNumber::from_be_bytes(block_number_bytes),
+            transaction_index: u32::from_be_bytes(transaction_index_bytes),
             hash: hash.to_string()
         }))
     }

--- a/crates/storage/src/db/read/transactions_table.rs
+++ b/crates/storage/src/db/read/transactions_table.rs
@@ -1,0 +1,125 @@
+use anyhow::{bail, ensure};
+use arrow::{
+    array::{Array, AsArray},
+    datatypes::{DataType, UInt16Type, UInt32Type, UInt64Type}
+};
+use sqd_array::{
+    builder::{AnyBuilder, ArrayBuilder},
+    reader::ArrayReader
+};
+use sqd_primitives::{BlockNumber, ItemIndex};
+
+use crate::{kv::KvRead, table::read::TableReader};
+
+/// Streams `(block number, transaction index, hash)` from an EVM transactions
+/// table in bounded batches. Required position/hash columns must contain no
+/// nulls, and each transaction index must fit [`ItemIndex`]; accepting an
+/// invalid row would create an index entry that cannot be sound.
+pub fn for_each_transaction_hash<S: KvRead + Sync>(
+    transactions_table: &TableReader<S>,
+    mut visit: impl FnMut(BlockNumber, ItemIndex, &str) -> anyhow::Result<()>
+) -> anyhow::Result<()> {
+    const TRANSACTION_HASH_BATCH_SIZE: usize = 4096;
+
+    let schema = transactions_table.schema();
+
+    let block_number_idx = schema.index_of("block_number")?;
+    let block_number_type = schema.field(block_number_idx).data_type().clone();
+    match block_number_type {
+        DataType::UInt32 | DataType::UInt64 => {}
+        ref ty => bail!("'block_number' column has unexpected data type - {}", ty)
+    }
+
+    let transaction_index_idx = schema.index_of("transaction_index")?;
+    let transaction_index_type = schema.field(transaction_index_idx).data_type().clone();
+    match transaction_index_type {
+        DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {}
+        ref ty => bail!("'transaction_index' column has unexpected data type - {}", ty)
+    }
+
+    let hash_idx = schema.index_of("hash")?;
+    let hash_type = schema.field(hash_idx).data_type().clone();
+    if hash_type != DataType::Utf8 {
+        bail!("'hash' column has unexpected data type - {}", hash_type)
+    }
+
+    let num_rows = transactions_table.num_rows();
+    let mut block_number_reader = transactions_table.create_column_reader(block_number_idx)?;
+    let mut transaction_index_reader = transactions_table.create_column_reader(transaction_index_idx)?;
+    let mut hash_reader = transactions_table.create_column_reader(hash_idx)?;
+
+    let mut offset = 0;
+    while offset < num_rows {
+        let len = std::cmp::min(TRANSACTION_HASH_BATCH_SIZE, num_rows - offset);
+
+        let block_numbers = {
+            let mut builder = AnyBuilder::new(&block_number_type);
+            block_number_reader.read_slice(&mut builder, offset, len)?;
+            builder.finish()
+        };
+        let transaction_indexes = {
+            let mut builder = AnyBuilder::new(&transaction_index_type);
+            transaction_index_reader.read_slice(&mut builder, offset, len)?;
+            builder.finish()
+        };
+        let hashes = {
+            let mut builder = AnyBuilder::new(&hash_type);
+            hash_reader.read_slice(&mut builder, offset, len)?;
+            builder.finish()
+        };
+
+        ensure!(
+            block_numbers.null_count() == 0 && transaction_indexes.null_count() == 0 && hashes.null_count() == 0,
+            "transaction position and hash columns must not contain nulls"
+        );
+
+        let transaction_indexes = match transaction_indexes.data_type() {
+            DataType::UInt16 => TransactionIndexes::UInt16(transaction_indexes.as_primitive::<UInt16Type>().values()),
+            DataType::UInt32 => TransactionIndexes::UInt32(transaction_indexes.as_primitive::<UInt32Type>().values()),
+            DataType::UInt64 => TransactionIndexes::UInt64(transaction_indexes.as_primitive::<UInt64Type>().values()),
+            _ => unreachable!("'transaction_index' column type was validated above")
+        };
+        let hashes = hashes.as_string::<i32>();
+
+        match block_numbers.data_type() {
+            DataType::UInt32 => {
+                let block_numbers = block_numbers.as_primitive::<UInt32Type>().values();
+                for i in 0..len {
+                    visit(
+                        BlockNumber::from(block_numbers[i]),
+                        transaction_indexes.value(i)?,
+                        hashes.value(i)
+                    )?;
+                }
+            }
+            DataType::UInt64 => {
+                let block_numbers = block_numbers.as_primitive::<UInt64Type>().values();
+                for i in 0..len {
+                    visit(block_numbers[i], transaction_indexes.value(i)?, hashes.value(i))?;
+                }
+            }
+            _ => unreachable!("'block_number' column type was validated above")
+        }
+
+        offset += len;
+    }
+
+    Ok(())
+}
+
+enum TransactionIndexes<'a> {
+    UInt16(&'a [u16]),
+    UInt32(&'a [u32]),
+    UInt64(&'a [u64])
+}
+
+impl TransactionIndexes<'_> {
+    fn value(&self, index: usize) -> anyhow::Result<ItemIndex> {
+        match self {
+            Self::UInt16(values) => Ok(ItemIndex::from(values[index])),
+            Self::UInt32(values) => Ok(values[index]),
+            Self::UInt64(values) => ItemIndex::try_from(values[index])
+                .map_err(|_| anyhow::anyhow!("transaction_index {} does not fit u32", values[index]))
+        }
+    }
+}

--- a/crates/storage/src/db/write/dataset_update.rs
+++ b/crates/storage/src/db/write/dataset_update.rs
@@ -30,7 +30,7 @@ impl<'a> DatasetUpdate<'a> {
     pub fn insert_chunk(&self, chunk: &Chunk) -> anyhow::Result<()> {
         self.tx.validate_chunk_insertion(self.dataset_id, chunk)?;
         self.tx.write_chunk(self.dataset_id, chunk)?;
-        self.tx.index_block_hashes(self.dataset_id, chunk)
+        self.tx.index_hashes(self.dataset_id, chunk)
     }
 
     pub fn insert_fork(&self, chunk: &Chunk) -> anyhow::Result<()> {
@@ -48,7 +48,7 @@ impl<'a> DatasetUpdate<'a> {
     }
 
     pub fn delete_chunk(&self, chunk: &Chunk) -> anyhow::Result<()> {
-        self.tx.unindex_block_hashes(self.dataset_id, chunk)?;
+        self.tx.unindex_hashes(self.dataset_id, chunk)?;
         self.tx.delete_chunk(self.dataset_id, chunk)
     }
 

--- a/crates/storage/src/db/write/tx.rs
+++ b/crates/storage/src/db/write/tx.rs
@@ -1,22 +1,24 @@
 use std::{
     cell::RefCell,
     cmp::{max, min},
-    sync::atomic::{AtomicU64, Ordering}
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant}
 };
 
 use anyhow::{anyhow, bail, ensure, Context};
 use rocksdb::ColumnFamily;
-use sqd_primitives::BlockNumber;
+use sqd_primitives::{BlockNumber, ItemIndex};
 
 use crate::db::{
-    data::{BlockHashIndexKey, ChunkId},
+    data::{ChunkId, HashIndexKey},
     db::{
         RocksDB, RocksIterator, RocksTransaction, RocksTransactionOptions, CF_BLOCK_HASHES, CF_CHUNKS, CF_DATASETS,
-        CF_DELETED_TABLES, CF_DIRTY_TABLES
+        CF_DELETED_TABLES, CF_DIRTY_TABLES, CF_TRANSACTION_HASHES
     },
     read::{
         blocks_table::{for_each_block_hash, get_parent_block_hash},
-        chunk::ChunkIterator
+        chunk::ChunkIterator,
+        transactions_table::for_each_transaction_hash
     },
     table_id::TableId,
     Chunk, DatasetId, DatasetKind, DatasetLabel, ReadSnapshot
@@ -41,17 +43,88 @@ fn record_restart() {
     LOCAL_RESTARTS.with_borrow_mut(|val| *val = val.wrapping_add(1))
 }
 
-/// Datasets whose block hashes get indexed in `CF_BLOCK_HASHES`. EVM-only for
-/// now; hyperliquid must stay out - its `hash` is not a crypto hash and can
+/// Dataset kinds covered by the derived hash indexes. EVM-only for now;
+/// hyperliquid must stay out because its `hash` is not a crypto hash and can
 /// collide.
 fn is_indexed_kind(kind: DatasetKind) -> bool {
     kind == DatasetKind::from_str("evm")
 }
 
+/// Aggregate time spent staging derived hash-index changes in an optimistic
+/// storage transaction, including work repeated after transaction conflicts.
+/// Timings are collected once per index scan, never once per entry.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HashIndexWriteMetrics {
+    block_hash_index_duration: Duration,
+    block_hash_index_operations: u64,
+    transaction_hash_index_duration: Duration,
+    transaction_hash_index_operations: u64
+}
+
+impl HashIndexWriteMetrics {
+    /// Total time spent staging block-hash index changes, if the update
+    /// performed any block-hash index scans.
+    pub fn block_hash_index_duration(&self) -> Option<Duration> {
+        (self.block_hash_index_operations > 0).then_some(self.block_hash_index_duration)
+    }
+
+    /// Number of block-hash index scans, including retried transaction attempts.
+    pub fn block_hash_index_operations(&self) -> u64 {
+        self.block_hash_index_operations
+    }
+
+    /// Total time spent staging transaction-hash index changes, if the update
+    /// performed any transaction-hash index scans.
+    pub fn transaction_hash_index_duration(&self) -> Option<Duration> {
+        (self.transaction_hash_index_operations > 0).then_some(self.transaction_hash_index_duration)
+    }
+
+    /// Number of transaction-hash index scans, including retried attempts.
+    pub fn transaction_hash_index_operations(&self) -> u64 {
+        self.transaction_hash_index_operations
+    }
+
+    fn record(&mut self, index: HashIndex, duration: Duration) {
+        match index {
+            HashIndex::Block => {
+                self.block_hash_index_duration = self.block_hash_index_duration.saturating_add(duration);
+                self.block_hash_index_operations = self.block_hash_index_operations.saturating_add(1);
+            }
+            HashIndex::Transaction => {
+                self.transaction_hash_index_duration = self.transaction_hash_index_duration.saturating_add(duration);
+                self.transaction_hash_index_operations = self.transaction_hash_index_operations.saturating_add(1);
+            }
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.block_hash_index_duration = self
+            .block_hash_index_duration
+            .saturating_add(other.block_hash_index_duration);
+        self.block_hash_index_operations = self
+            .block_hash_index_operations
+            .saturating_add(other.block_hash_index_operations);
+        self.transaction_hash_index_duration = self
+            .transaction_hash_index_duration
+            .saturating_add(other.transaction_hash_index_duration);
+        self.transaction_hash_index_operations = self
+            .transaction_hash_index_operations
+            .saturating_add(other.transaction_hash_index_operations);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HashIndex {
+    Block,
+    Transaction
+}
+
 pub struct Tx<'a> {
     db: &'a RocksDB,
     transaction: RocksTransaction<'a>,
-    block_hash_index: bool
+    block_hash_index: bool,
+    transaction_hash_index: bool,
+    hash_index_write_metrics: RefCell<HashIndexWriteMetrics>
 }
 
 impl<'a> Tx<'a> {
@@ -64,7 +137,9 @@ impl<'a> Tx<'a> {
         Self {
             db,
             transaction,
-            block_hash_index: false
+            block_hash_index: false,
+            transaction_hash_index: false,
+            hash_index_write_metrics: RefCell::new(HashIndexWriteMetrics::default())
         }
     }
 
@@ -75,28 +150,72 @@ impl<'a> Tx<'a> {
         self
     }
 
-    pub fn run<R, F>(self, mut cb: F) -> anyhow::Result<R>
+    /// Enables transaction hash indexing for chunks written through this
+    /// transaction. The switch is intentionally independent of block hashes.
+    pub fn with_transaction_hash_index(mut self, yes: bool) -> Self {
+        self.transaction_hash_index = yes;
+        self
+    }
+
+    pub fn run<R, F>(self, cb: F) -> anyhow::Result<R>
+    where
+        F: FnMut(&Self) -> anyhow::Result<R>
+    {
+        let mut metrics = HashIndexWriteMetrics::default();
+        self.run_with_hash_index_metrics(&mut metrics, cb)
+    }
+
+    pub(crate) fn run_with_hash_index_metrics<R, F>(
+        self,
+        metrics: &mut HashIndexWriteMetrics,
+        mut cb: F
+    ) -> anyhow::Result<R>
     where
         F: FnMut(&Self) -> anyhow::Result<R>
     {
         let db = self.db;
         let block_hash_index = self.block_hash_index;
+        let transaction_hash_index = self.transaction_hash_index;
         let mut tx = self;
         loop {
-            let result = cb(&tx)?;
-            match tx.commit() {
+            let result = match cb(&tx) {
+                Ok(result) => result,
+                Err(err) => {
+                    metrics.merge(tx.hash_index_write_metrics.into_inner());
+                    return Err(err);
+                }
+            };
+            let (commit_result, attempt_metrics) = tx.commit();
+            metrics.merge(attempt_metrics);
+            match commit_result {
                 Ok(_) => return Ok(result),
                 Err(err) if err.kind() == rocksdb::ErrorKind::TryAgain || err.kind() == rocksdb::ErrorKind::Busy => {
                     record_restart();
-                    tx = Self::new(db).with_block_hash_index(block_hash_index)
+                    tx = Self::new(db)
+                        .with_block_hash_index(block_hash_index)
+                        .with_transaction_hash_index(transaction_hash_index)
                 }
                 Err(err) => return Err(err.into())
             }
         }
     }
 
-    pub fn commit(self) -> Result<(), rocksdb::Error> {
-        self.transaction.commit()
+    fn commit(self) -> (Result<(), rocksdb::Error>, HashIndexWriteMetrics) {
+        let Self {
+            transaction,
+            hash_index_write_metrics,
+            ..
+        } = self;
+        (transaction.commit(), hash_index_write_metrics.into_inner())
+    }
+
+    fn measure_hash_index<R>(&self, index: HashIndex, cb: impl FnOnce() -> anyhow::Result<R>) -> anyhow::Result<R> {
+        let started = Instant::now();
+        let result = cb();
+        self.hash_index_write_metrics
+            .borrow_mut()
+            .record(index, started.elapsed());
+        result
     }
 
     pub fn find_label_for_update(&self, dataset_id: DatasetId) -> anyhow::Result<Option<DatasetLabel>> {
@@ -156,11 +275,10 @@ impl<'a> Tx<'a> {
         Ok(())
     }
 
-    /// Adds every `(hash, block number)` pair of `chunk`'s `blocks` table to
-    /// `CF_BLOCK_HASHES`. No-op unless indexing is enabled on this transaction
-    /// and the dataset kind is whitelisted in [`is_indexed_kind`].
-    pub fn index_block_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
-        if !self.block_hash_index {
+    /// Adds the enabled derived-index entries for `chunk`. Both indexes are
+    /// staged in the same optimistic transaction as chunk metadata.
+    pub(crate) fn index_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
+        if !self.block_hash_index && !self.transaction_hash_index {
             return Ok(());
         }
 
@@ -171,6 +289,18 @@ impl<'a> Tx<'a> {
             return Ok(());
         }
 
+        if self.block_hash_index {
+            self.measure_hash_index(HashIndex::Block, || self.index_block_hashes(dataset_id, chunk))?;
+        }
+        if self.transaction_hash_index {
+            self.measure_hash_index(HashIndex::Transaction, || {
+                self.index_transaction_hashes(dataset_id, chunk)
+            })?;
+        }
+        Ok(())
+    }
+
+    fn index_block_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
         let Some(blocks_table_id) = chunk.tables().get("blocks").copied() else {
             return Ok(()); // defensively skip chunks without a blocks table
         };
@@ -178,22 +308,47 @@ impl<'a> Tx<'a> {
         let snapshot = ReadSnapshot::new(self.db);
         let reader = snapshot.create_table_reader(blocks_table_id)?;
         let cf = self.cf_handle(CF_BLOCK_HASHES);
+        let mut key = HashIndexKey::new(dataset_id, "");
         for_each_block_hash(&reader, |number, hash| {
-            self.transaction
-                .put_cf(cf, BlockHashIndexKey::new(dataset_id, hash), number.to_be_bytes())?;
+            key.set_hash(hash);
+            self.transaction.put_cf(cf, &key, number.to_be_bytes())?;
             Ok(())
         })
     }
 
-    /// Removes every hash of `chunk`'s `blocks` table from `CF_BLOCK_HASHES`.
+    fn index_transaction_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
+        let Some(transactions_table_id) = chunk.tables().get("transactions").copied() else {
+            return Ok(());
+        };
+
+        let snapshot = ReadSnapshot::new(self.db);
+        let reader = snapshot.create_table_reader(transactions_table_id)?;
+        let cf = self.cf_handle(CF_TRANSACTION_HASHES);
+        let mut key = HashIndexKey::new(dataset_id, "");
+        for_each_transaction_hash(&reader, |block_number, transaction_index, hash| {
+            key.set_hash(hash);
+            self.transaction
+                .put_cf(cf, &key, encode_transaction_position(block_number, transaction_index))?;
+            Ok(())
+        })
+    }
+
+    /// Removes every hash-index entry contributed by `chunk`.
     ///
-    /// Unlike [`Tx::index_block_hashes`], gated on neither the flag nor the
-    /// dataset kind, but on whether the dataset has any entries at all -
-    /// entries written while the flag was on must still be removed when their
-    /// chunk is pruned, or they would be stranded forever. Idempotent over
-    /// never-indexed chunks: `delete_cf` on a missing key is a no-op.
-    pub fn unindex_block_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
-        if !self.has_block_hash_entries(dataset_id)? {
+    /// Removal is gated on neither flag nor dataset kind: entries written while
+    /// a flag was on must still be removed when their chunk is pruned, or they
+    /// would be stranded forever. Each column family is first probed with one
+    /// prefix seek, making never-indexed chunks cheap and idempotent.
+    pub(crate) fn unindex_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
+        self.measure_hash_index(HashIndex::Block, || self.unindex_block_hashes(dataset_id, chunk))?;
+        self.measure_hash_index(HashIndex::Transaction, || {
+            self.unindex_transaction_hashes(dataset_id, chunk)
+        })
+    }
+
+    fn unindex_block_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
+        let cf = self.cf_handle(CF_BLOCK_HASHES);
+        if !self.has_hash_entries(cf, dataset_id)? {
             return Ok(());
         }
 
@@ -203,27 +358,45 @@ impl<'a> Tx<'a> {
 
         let snapshot = ReadSnapshot::new(self.db);
         let reader = snapshot.create_table_reader(blocks_table_id)?;
-        let cf = self.cf_handle(CF_BLOCK_HASHES);
+        let mut key = HashIndexKey::new(dataset_id, "");
         for_each_block_hash(&reader, |_number, hash| {
-            self.transaction
-                .delete_cf(cf, BlockHashIndexKey::new(dataset_id, hash))?;
+            key.set_hash(hash);
+            self.transaction.delete_cf(cf, &key)?;
             Ok(())
         })
     }
 
-    /// Whether `dataset_id` holds at least one `CF_BLOCK_HASHES` entry: a
-    /// single seek. Iterating the transaction (not the bare DB) keeps the
-    /// answer accurate part-way through a multi-chunk `insert_fork`.
-    fn has_block_hash_entries(&self, dataset_id: DatasetId) -> anyhow::Result<bool> {
-        let (start, end) = BlockHashIndexKey::dataset_range(dataset_id);
+    fn unindex_transaction_hashes(&self, dataset_id: DatasetId, chunk: &Chunk) -> anyhow::Result<()> {
+        let cf = self.cf_handle(CF_TRANSACTION_HASHES);
+        if !self.has_hash_entries(cf, dataset_id)? {
+            return Ok(());
+        }
+
+        let Some(transactions_table_id) = chunk.tables().get("transactions").copied() else {
+            return Ok(());
+        };
+
+        let snapshot = ReadSnapshot::new(self.db);
+        let reader = snapshot.create_table_reader(transactions_table_id)?;
+        let mut key = HashIndexKey::new(dataset_id, "");
+        for_each_transaction_hash(&reader, |_block_number, _transaction_index, hash| {
+            key.set_hash(hash);
+            self.transaction.delete_cf(cf, &key)?;
+            Ok(())
+        })
+    }
+
+    /// Whether `dataset_id` holds at least one entry in `cf`: a single seek.
+    /// Iterating the transaction (not the bare DB) keeps the answer accurate
+    /// part-way through a multi-chunk `insert_fork`.
+    fn has_hash_entries(&self, cf: &ColumnFamily, dataset_id: DatasetId) -> anyhow::Result<bool> {
+        let (start, end) = HashIndexKey::dataset_range(dataset_id);
 
         let mut read_opts = rocksdb::ReadOptions::default();
         read_opts.set_snapshot(&self.transaction.snapshot());
         read_opts.set_iterate_upper_bound(end);
 
-        let mut cursor = self
-            .transaction
-            .raw_iterator_cf_opt(self.cf_handle(CF_BLOCK_HASHES), read_opts);
+        let mut cursor = self.transaction.raw_iterator_cf_opt(cf, read_opts);
 
         cursor.seek(&start);
         cursor.status()?;
@@ -237,7 +410,7 @@ impl<'a> Tx<'a> {
         for head_result in existing {
             let head = head_result?;
             if chunk.first_block() <= head.first_block() {
-                self.unindex_block_hashes(dataset_id, &head)?;
+                self.unindex_hashes(dataset_id, &head)?;
                 self.delete_chunk(dataset_id, &head)?;
             } else if head.last_block() + 1 == chunk.first_block() {
                 ensure!(
@@ -260,7 +433,7 @@ impl<'a> Tx<'a> {
         }
 
         self.write_chunk(dataset_id, chunk)?;
-        self.index_block_hashes(dataset_id, chunk)?;
+        self.index_hashes(dataset_id, chunk)?;
 
         Ok(())
     }
@@ -367,4 +540,11 @@ impl<'a> Tx<'a> {
     fn cf_handle(&self, name: &str) -> &ColumnFamily {
         self.db.cf_handle(name).unwrap()
     }
+}
+
+fn encode_transaction_position(block_number: BlockNumber, transaction_index: ItemIndex) -> [u8; 12] {
+    let mut bytes = [0; 12];
+    bytes[..8].copy_from_slice(&block_number.to_be_bytes());
+    bytes[8..].copy_from_slice(&transaction_index.to_be_bytes());
+    bytes
 }

--- a/crates/storage/tests/block_hash_index.rs
+++ b/crates/storage/tests/block_hash_index.rs
@@ -6,7 +6,7 @@ use arrow::{
 };
 use sqd_primitives::BlockRef;
 use sqd_storage::{
-    db::{Chunk, CompactionStatus, Database, DatabaseSettings, DatasetId, DatasetKind},
+    db::{Chunk, CompactionStatus, Database, DatabaseSettings, DatasetId, DatasetKind, HashIndexWriteMetrics},
     table::write::use_small_buffers
 };
 use tempfile::TempDir;
@@ -88,6 +88,33 @@ fn make_evm_chunk(db: &Database, first: u64, last: u64, parent_hash: &str) -> Ch
     make_evm_chunk_with(db, first, last, parent_hash, block_hash)
 }
 
+fn make_evm_chunk_with_null_hash(db: &Database) -> Chunk {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("number", DataType::UInt64, false),
+        Field::new("hash", DataType::Utf8, true),
+    ]));
+    let numbers = Arc::new(UInt64Array::from(vec![0, 1])) as ArrayRef;
+    let first_hash = block_hash(0);
+    let hashes = Arc::new(StringArray::from(vec![Some(first_hash.as_str()), None])) as ArrayRef;
+
+    let mut builder = db.new_table_builder(schema.clone());
+    let batch = RecordBatch::try_new(schema, vec![numbers, hashes]).unwrap();
+    builder.write_record_batch(&batch).unwrap();
+
+    let mut tables = BTreeMap::new();
+    tables.insert("blocks".to_owned(), builder.finish().unwrap());
+
+    Chunk::V1 {
+        first_block: 0,
+        last_block: 1,
+        last_block_hash: block_hash(1),
+        parent_block_hash: "base".to_owned(),
+        first_block_time: None,
+        last_block_time: None,
+        tables
+    }
+}
+
 fn lookup(db: &Database, dataset_id: DatasetId, hash: &str) -> Option<BlockRef> {
     db.snapshot().find_block_by_hash(dataset_id, hash).unwrap()
 }
@@ -120,6 +147,39 @@ fn index_ingest_and_lookup() {
     }
     assert_absent(&db, dataset_id, "0xdeadbeef");
     assert_absent(&db, dataset_id, &block_hash(10));
+}
+
+#[test]
+fn observed_update_reports_block_hash_index_work() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let chunk = make_evm_chunk(&db, 0, 9, "base");
+    let mut metrics = HashIndexWriteMetrics::default();
+
+    db.update_dataset_with_hash_index_metrics(dataset_id, &mut metrics, |tx| tx.insert_chunk(&chunk))
+        .unwrap();
+
+    assert_eq!(metrics.block_hash_index_operations(), 1);
+    assert_eq!(metrics.transaction_hash_index_operations(), 0);
+    assert!(metrics.block_hash_index_duration().is_some());
+    assert!(metrics.transaction_hash_index_duration().is_none());
+    for n in 0..=9 {
+        assert_resolves(&db, dataset_id, n);
+    }
+}
+
+#[test]
+fn block_index_rejects_null_hash_without_publishing_the_chunk() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let chunk = make_evm_chunk_with_null_hash(&db);
+
+    let err = db.insert_chunk(dataset_id, &chunk).unwrap_err();
+
+    assert!(
+        format!("{err:#}").contains("block number and hash columns must not contain nulls"),
+        "unexpected error: {err:#}"
+    );
+    assert!(db.snapshot().get_last_chunk(dataset_id).unwrap().is_none());
+    assert_absent(&db, dataset_id, &block_hash(0));
 }
 
 #[test]

--- a/crates/storage/tests/transaction_hash_index.rs
+++ b/crates/storage/tests/transaction_hash_index.rs
@@ -1,0 +1,465 @@
+use std::{
+    collections::BTreeMap,
+    sync::{mpsc, Arc},
+    thread,
+    time::Duration
+};
+
+use arrow::{
+    array::{ArrayRef, RecordBatch, StringArray, UInt32Array, UInt64Array},
+    datatypes::{DataType, Field, Schema}
+};
+use sqd_primitives::TransactionRef;
+use sqd_storage::{
+    db::{Chunk, CompactionStatus, Database, DatabaseSettings, DatasetId, DatasetKind, HashIndexWriteMetrics},
+    table::write::use_small_buffers
+};
+use tempfile::TempDir;
+
+#[derive(Clone, Debug)]
+struct TransactionRow {
+    block_number: u64,
+    transaction_index: u32,
+    hash: String
+}
+
+fn open_db_with(kind: &str, block_hash_index: bool, transaction_hash_index: bool) -> (TempDir, Database, DatasetId) {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db = reopen(&db_dir, block_hash_index, transaction_hash_index);
+    let dataset_id = DatasetId::from_str("test-dataset");
+    db.create_dataset(dataset_id, DatasetKind::from_str(kind)).unwrap();
+    (db_dir, db, dataset_id)
+}
+
+fn reopen(dir: &TempDir, block_hash_index: bool, transaction_hash_index: bool) -> Database {
+    DatabaseSettings::default()
+        .with_block_hash_index(block_hash_index)
+        .with_transaction_hash_index(transaction_hash_index)
+        .open(dir.path())
+        .unwrap()
+}
+
+fn setup_evm_db() -> (TempDir, Database, DatasetId) {
+    open_db_with("evm", false, true)
+}
+
+fn block_hash(n: u64) -> String {
+    format!("0x{n:064x}")
+}
+
+fn transaction_hash(block_number: u64, transaction_index: u32, fork: u32) -> String {
+    format!("0x{fork:08x}{block_number:048x}{transaction_index:08x}")
+}
+
+fn transaction_rows(first: u64, last: u64, per_block: u32, fork: u32) -> Vec<TransactionRow> {
+    (first..=last)
+        .flat_map(|block_number| {
+            (0..per_block).map(move |transaction_index| TransactionRow {
+                block_number,
+                transaction_index,
+                hash: transaction_hash(block_number, transaction_index, fork)
+            })
+        })
+        .collect()
+}
+
+fn make_evm_chunk(db: &Database, first: u64, last: u64, parent_hash: &str, transactions: &[TransactionRow]) -> Chunk {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("block_number", DataType::UInt64, false),
+        Field::new("transaction_index", DataType::UInt32, false),
+        Field::new("hash", DataType::Utf8, false),
+    ]));
+    let block_numbers = Arc::new(UInt64Array::from(
+        transactions.iter().map(|row| row.block_number).collect::<Vec<_>>()
+    )) as ArrayRef;
+    let transaction_indexes = Arc::new(UInt32Array::from(
+        transactions.iter().map(|row| row.transaction_index).collect::<Vec<_>>()
+    )) as ArrayRef;
+    let hashes = Arc::new(StringArray::from(
+        transactions.iter().map(|row| row.hash.as_str()).collect::<Vec<_>>()
+    )) as ArrayRef;
+
+    let mut builder = db.new_table_builder(schema.clone());
+    let batch = RecordBatch::try_new(schema, vec![block_numbers, transaction_indexes, hashes]).unwrap();
+    builder.write_record_batch(&batch).unwrap();
+
+    let mut tables = BTreeMap::new();
+    tables.insert("transactions".to_owned(), builder.finish().unwrap());
+
+    Chunk::V1 {
+        first_block: first,
+        last_block: last,
+        last_block_hash: block_hash(last),
+        parent_block_hash: parent_hash.to_owned(),
+        first_block_time: None,
+        last_block_time: None,
+        tables
+    }
+}
+
+fn make_evm_chunk_with_u64_transaction_index(db: &Database, transaction_index: u64) -> (Chunk, String) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("block_number", DataType::UInt64, false),
+        Field::new("transaction_index", DataType::UInt64, false),
+        Field::new("hash", DataType::Utf8, false),
+    ]));
+    let hash = transaction_hash(0, 0, 0);
+    let block_numbers = Arc::new(UInt64Array::from(vec![0])) as ArrayRef;
+    let transaction_indexes = Arc::new(UInt64Array::from(vec![transaction_index])) as ArrayRef;
+    let hashes = Arc::new(StringArray::from(vec![hash.as_str()])) as ArrayRef;
+
+    let mut builder = db.new_table_builder(schema.clone());
+    let batch = RecordBatch::try_new(schema, vec![block_numbers, transaction_indexes, hashes]).unwrap();
+    builder.write_record_batch(&batch).unwrap();
+
+    let mut tables = BTreeMap::new();
+    tables.insert("transactions".to_owned(), builder.finish().unwrap());
+
+    (
+        Chunk::V1 {
+            first_block: 0,
+            last_block: 0,
+            last_block_hash: block_hash(0),
+            parent_block_hash: "base".to_owned(),
+            first_block_time: None,
+            last_block_time: None,
+            tables
+        },
+        hash
+    )
+}
+
+fn lookup(db: &Database, dataset_id: DatasetId, hash: &str) -> Option<TransactionRef> {
+    db.snapshot().find_transaction_by_hash(dataset_id, hash).unwrap()
+}
+
+fn assert_resolves(db: &Database, dataset_id: DatasetId, row: &TransactionRow) {
+    assert_eq!(
+        lookup(db, dataset_id, &row.hash),
+        Some(TransactionRef {
+            block_number: row.block_number,
+            transaction_index: row.transaction_index,
+            hash: row.hash.clone()
+        }),
+        "transaction {} should resolve to ({}, {})",
+        row.hash,
+        row.block_number,
+        row.transaction_index
+    );
+}
+
+fn assert_absent(db: &Database, dataset_id: DatasetId, hash: &str) {
+    assert_eq!(lookup(db, dataset_id, hash), None, "hash {hash} should not resolve");
+}
+
+#[test]
+fn index_ingest_and_lookup() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let rows = transaction_rows(0, 9, 3, 0);
+    let chunk = make_evm_chunk(&db, 0, 9, "base", &rows);
+
+    db.insert_chunk(dataset_id, &chunk).unwrap();
+
+    for row in &rows {
+        assert_resolves(&db, dataset_id, row);
+    }
+    assert_absent(&db, dataset_id, "0xdeadbeef");
+}
+
+#[test]
+fn observed_update_reports_transaction_hash_index_work() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let rows = transaction_rows(0, 9, 3, 0);
+    let chunk = make_evm_chunk(&db, 0, 9, "base", &rows);
+    let mut metrics = HashIndexWriteMetrics::default();
+
+    db.update_dataset_with_hash_index_metrics(dataset_id, &mut metrics, |tx| tx.insert_chunk(&chunk))
+        .unwrap();
+
+    assert_eq!(metrics.block_hash_index_operations(), 0);
+    assert_eq!(metrics.transaction_hash_index_operations(), 1);
+    assert!(metrics.block_hash_index_duration().is_none());
+    assert!(metrics.transaction_hash_index_duration().is_some());
+    for row in &rows {
+        assert_resolves(&db, dataset_id, row);
+    }
+}
+
+#[test]
+fn transaction_index_rejects_out_of_range_position_without_publishing_the_chunk() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let oversized_index = u64::from(u32::MAX) + 1;
+    let (chunk, hash) = make_evm_chunk_with_u64_transaction_index(&db, oversized_index);
+
+    let err = db.insert_chunk(dataset_id, &chunk).unwrap_err();
+
+    assert!(
+        format!("{err:#}").contains(&format!("transaction_index {oversized_index} does not fit u32")),
+        "unexpected error: {err:#}"
+    );
+    assert!(db.snapshot().get_last_chunk(dataset_id).unwrap().is_none());
+    assert_absent(&db, dataset_id, &hash);
+}
+
+#[test]
+fn index_large_chunk_spans_multiple_read_batches() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let rows = transaction_rows(0, 4, 1_025, 0);
+    assert!(rows.len() > 4096);
+    let chunk = make_evm_chunk(&db, 0, 4, "base", &rows);
+
+    db.insert_chunk(dataset_id, &chunk).unwrap();
+
+    for index in [0, 1, 4095, 4096, 4097, rows.len() - 1] {
+        assert_resolves(&db, dataset_id, &rows[index]);
+    }
+}
+
+#[test]
+fn fork_removes_stale_hashes_and_reinclusion_names_the_new_position() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+
+    let rows1 = transaction_rows(0, 9, 2, 0);
+    let mut rows2 = transaction_rows(10, 19, 2, 0);
+    let reincluded_hash = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    rows2[4].hash = reincluded_hash.to_owned(); // old position: block 12, index 0
+    let chunk1 = make_evm_chunk(&db, 0, 9, "base", &rows1);
+    let chunk2 = make_evm_chunk(&db, 10, 19, &block_hash(9), &rows2);
+    db.insert_chunk(dataset_id, &chunk1).unwrap();
+    db.insert_chunk(dataset_id, &chunk2).unwrap();
+
+    let mut fork_rows = transaction_rows(10, 19, 2, 1);
+    fork_rows[11].hash = reincluded_hash.to_owned(); // new position: block 15, index 1
+    let fork = make_evm_chunk(&db, 10, 19, &block_hash(9), &fork_rows);
+    db.insert_fork(dataset_id, &fork).unwrap();
+
+    for row in &rows1 {
+        assert_resolves(&db, dataset_id, row);
+    }
+    for row in &rows2 {
+        if row.hash != reincluded_hash {
+            assert_absent(&db, dataset_id, &row.hash);
+        }
+    }
+    for row in &fork_rows {
+        assert_resolves(&db, dataset_id, row);
+    }
+    assert_eq!(
+        lookup(&db, dataset_id, reincluded_hash),
+        Some(TransactionRef {
+            block_number: 15,
+            transaction_index: 1,
+            hash: reincluded_hash.to_owned()
+        })
+    );
+}
+
+#[test]
+fn retention_removes_only_the_pruned_chunks_transactions() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let rows1 = transaction_rows(0, 9, 2, 0);
+    let rows2 = transaction_rows(10, 19, 2, 0);
+    let chunk1 = make_evm_chunk(&db, 0, 9, "base", &rows1);
+    let chunk2 = make_evm_chunk(&db, 10, 19, &block_hash(9), &rows2);
+    db.insert_chunk(dataset_id, &chunk1).unwrap();
+    db.insert_chunk(dataset_id, &chunk2).unwrap();
+
+    db.update_dataset(dataset_id, |tx| tx.delete_chunk(&chunk1)).unwrap();
+
+    for row in &rows1 {
+        assert_absent(&db, dataset_id, &row.hash);
+    }
+    for row in &rows2 {
+        assert_resolves(&db, dataset_id, row);
+    }
+}
+
+#[test]
+fn delete_dataset_purges_all_transaction_hashes() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let rows = transaction_rows(0, 19, 2, 0);
+    let chunk = make_evm_chunk(&db, 0, 19, "base", &rows);
+    db.insert_chunk(dataset_id, &chunk).unwrap();
+
+    db.delete_dataset(dataset_id).unwrap();
+
+    assert!(db.get_all_datasets().unwrap().is_empty());
+    for row in &rows {
+        assert_absent(&db, dataset_id, &row.hash);
+    }
+}
+
+#[test]
+fn compaction_preserves_the_transaction_index() {
+    let (_dir, db, dataset_id) = setup_evm_db();
+    let _small_buffers = use_small_buffers();
+    let mut all_rows = Vec::new();
+    let mut parent = "base".to_owned();
+
+    for block in 0..60 {
+        let rows = transaction_rows(block, block, 2, 0);
+        let chunk = make_evm_chunk(&db, block, block, &parent, &rows);
+        db.insert_chunk(dataset_id, &chunk).unwrap();
+        all_rows.extend(rows);
+        parent = block_hash(block);
+    }
+
+    let mut merged = false;
+    while let CompactionStatus::Ok(_) = db
+        .perform_dataset_compaction(dataset_id, Some(100), Some(1.25), None)
+        .unwrap()
+    {
+        merged = true;
+    }
+    assert!(merged, "expected compaction to merge at least one chunk range");
+
+    for row in &all_rows {
+        assert_resolves(&db, dataset_id, row);
+    }
+}
+
+#[test]
+fn transaction_index_is_evm_only_and_independent_from_block_index() {
+    let (_dir, db, dataset_id) = open_db_with("solana", true, true);
+    let rows = transaction_rows(0, 1, 2, 0);
+    let chunk = make_evm_chunk(&db, 0, 1, "base", &rows);
+    db.insert_chunk(dataset_id, &chunk).unwrap();
+    for row in &rows {
+        assert_absent(&db, dataset_id, &row.hash);
+    }
+
+    let (_dir, db, dataset_id) = open_db_with("evm", true, false);
+    let rows = transaction_rows(0, 1, 2, 0);
+    let chunk = make_evm_chunk(&db, 0, 1, "base", &rows);
+    db.insert_chunk(dataset_id, &chunk).unwrap();
+    for row in &rows {
+        assert_absent(&db, dataset_id, &row.hash);
+    }
+}
+
+#[test]
+fn enabling_the_index_does_not_backfill_existing_chunks() {
+    let (dir, db, dataset_id) = open_db_with("evm", false, false);
+    let old_rows = transaction_rows(0, 9, 2, 0);
+    let old_chunk = make_evm_chunk(&db, 0, 9, "base", &old_rows);
+    db.insert_chunk(dataset_id, &old_chunk).unwrap();
+    drop(db);
+
+    let db = reopen(&dir, false, true);
+    let new_rows = transaction_rows(10, 19, 2, 0);
+    let new_chunk = make_evm_chunk(&db, 10, 19, &block_hash(9), &new_rows);
+    db.insert_chunk(dataset_id, &new_chunk).unwrap();
+
+    for row in &old_rows {
+        assert_absent(&db, dataset_id, &row.hash);
+    }
+    for row in &new_rows {
+        assert_resolves(&db, dataset_id, row);
+    }
+}
+
+#[test]
+fn entries_drain_after_the_flag_is_turned_off() {
+    let (dir, db, dataset_id) = setup_evm_db();
+    let rows1 = transaction_rows(0, 9, 2, 0);
+    let rows2 = transaction_rows(10, 19, 2, 0);
+    let chunk1 = make_evm_chunk(&db, 0, 9, "base", &rows1);
+    let chunk2 = make_evm_chunk(&db, 10, 19, &block_hash(9), &rows2);
+    db.insert_chunk(dataset_id, &chunk1).unwrap();
+    db.insert_chunk(dataset_id, &chunk2).unwrap();
+    drop(db);
+
+    let db = reopen(&dir, false, false);
+    db.update_dataset(dataset_id, |tx| tx.delete_chunk(&chunk1)).unwrap();
+
+    for row in &rows1 {
+        assert_absent(&db, dataset_id, &row.hash);
+    }
+    for row in &rows2 {
+        assert_resolves(&db, dataset_id, row);
+    }
+}
+
+#[test]
+fn pending_large_index_write_does_not_block_reads_or_another_dataset_writer() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(
+        DatabaseSettings::default()
+            .with_transaction_hash_index(true)
+            .open(dir.path())
+            .unwrap()
+    );
+    let dataset_a = DatasetId::from_str("dataset-a");
+    let dataset_b = DatasetId::from_str("dataset-b");
+    for dataset_id in [dataset_a, dataset_b] {
+        db.create_dataset(dataset_id, DatasetKind::from_str("evm")).unwrap();
+    }
+
+    let seed_rows = transaction_rows(0, 0, 1, 0);
+    let seed = make_evm_chunk(&db, 0, 0, "base", &seed_rows);
+    db.insert_chunk(dataset_a, &seed).unwrap();
+
+    let staged_rows = transaction_rows(1, 1, 10_000, 0);
+    let staged_hash = staged_rows.last().unwrap().hash.clone();
+    let staged = make_evm_chunk(&db, 1, 1, &block_hash(0), &staged_rows);
+    let other_rows = transaction_rows(0, 0, 1, 0);
+    let other = make_evm_chunk(&db, 0, 0, "base", &other_rows);
+
+    let (ready_tx, ready_rx) = mpsc::sync_channel(0);
+    let (release_tx, release_rx) = mpsc::sync_channel(0);
+    let writer_db = Arc::clone(&db);
+    let writer = thread::spawn(move || {
+        writer_db.update_dataset(dataset_a, |tx| {
+            tx.insert_chunk(&staged)?;
+            ready_tx.send(())?;
+            release_rx.recv_timeout(Duration::from_secs(10))?;
+            Ok(())
+        })
+    });
+    ready_rx
+        .recv_timeout(Duration::from_secs(20))
+        .expect("large index transaction should reach the pre-commit gate");
+
+    let (probe_tx, probe_rx) = mpsc::sync_channel(0);
+    let probe_db = Arc::clone(&db);
+    let committed_hash = seed_rows[0].hash.clone();
+    let other_hash = other_rows[0].hash.clone();
+    let probe = thread::spawn(move || {
+        let result = (|| -> anyhow::Result<()> {
+            anyhow::ensure!(
+                probe_db
+                    .snapshot()
+                    .find_transaction_by_hash(dataset_a, &committed_hash)?
+                    .is_some(),
+                "a committed point read disappeared while another transaction was pending"
+            );
+            anyhow::ensure!(
+                probe_db
+                    .snapshot()
+                    .find_transaction_by_hash(dataset_a, &staged_hash)?
+                    .is_none(),
+                "an uncommitted index entry became visible"
+            );
+            probe_db.insert_chunk(dataset_b, &other)?;
+            anyhow::ensure!(
+                probe_db
+                    .snapshot()
+                    .find_transaction_by_hash(dataset_b, &other_hash)?
+                    .is_some(),
+                "the independent writer did not publish its index entry"
+            );
+            Ok(())
+        })();
+        probe_tx.send(result).unwrap();
+    });
+
+    let probe_result = probe_rx.recv_timeout(Duration::from_secs(10));
+    release_tx.send(()).unwrap();
+    probe.join().unwrap();
+    writer.join().unwrap().unwrap();
+
+    probe_result
+        .expect("read/independent-write probe was blocked by an uncommitted index transaction")
+        .unwrap();
+    assert!(lookup(&db, dataset_a, &staged_rows.last().unwrap().hash).is_some());
+}


### PR DESCRIPTION
## Summary

- add an independent, opt-in EVM transaction hash index and `GET /datasets/{id}/hashes/{hash}/transaction`
- maintain transaction entries atomically across ingest, forks, retention, compaction, and logical dataset deletion; purge physical DROP residue in bounded batches
- keep point lookups outside query/waiter budgets and Tokio runtime workers
- expose `hotblocks_write_duration_seconds{dataset,stage,outcome}` for `prepare`, `tables`, `commit`, and `retention`, with separate nested `block_hash_index` and `transaction_hash_index` stages
- add RocksDB Bloom filters to both hash indexes, LZ4 transaction-index compression, per-CF metrics, conformance coverage, and a server-listener startup log

The index is off by default, independent from the block hash index, and intentionally does not backfill.

## Performance

Release-mode Criterion results on the development machine:

- incremental index write cost: approximately 0.91-1.03 microseconds per transaction
- hot-cache lookup at 1,000 entries: approximately 0.64-0.66 microseconds
- hot-cache lookup at 100,000 entries: approximately 0.91-0.93 microseconds
- a staged 10,000-entry optimistic transaction did not block committed reads or an independent dataset writer; uncommitted entries remained invisible

Write-stage instrumentation does not update Prometheus per index entry. Storage reads the clock once around each block/transaction index scan, aggregates timings across optimistic-transaction retries, and publishes one histogram observation per completed top-level write after the storage operation returns. The read path is not instrumented by these write metrics.

## Disk footprint

A controlled release-mode A/B probe used identical random-looking 32-byte hashes, production key/value encodings, Bloom filters, and full compaction. Figures are live SST bytes for the named CF only, excluding WAL, memtables, and table data:

| Entries/index | Block, Snappy | Block, LZ4 | Transaction, Snappy | Transaction, LZ4 |
| ---: | ---: | ---: | ---: | ---: |
| 100,000 | 8,487,039 (84.87 B/e) | 8,486,380 (84.86 B/e) | 8,903,864 (89.04 B/e) | 8,904,184 (89.04 B/e) |
| 1,000,000 | 72,238,847 (72.24 B/e) | 71,885,934 (71.89 B/e) | 75,310,111 (75.31 B/e) | 75,037,601 (75.04 B/e) |

At one million entries, LZ4 saves only 0.49% for the block index and 0.36% for the transaction index. Use 70–90 B per retained entry as an initial capacity range: approximately 67 GiB per billion blocks and 70 GiB per billion transactions after compaction.

## Compression compatibility

Before this PR, the block-index CF used RocksDB default Snappy compression. The A/B difference is too small to justify recompression, so this PR now keeps `BLOCK_HASHES` explicitly on Snappy and configures only the new `TRANSACTION_HASHES` CF as LZ4.

No block-index codec migration, logical migration, or rebuild is required. Existing block SSTs and newly produced block SSTs remain Snappy.

## Validation

- `cargo test -p sqd-storage --lib --test block_hash_index --test transaction_hash_index`
- `cargo test -p sqd-storage --test database_ops --test cleanup_reclaim`
- `cargo test -p sqd-storage --lib create_purges_crash_residue_before_publishing_the_dataset_label`
- `cargo test -p sqd-hotblocks --test block_hash_index --test transaction_hash_index`
- `cargo test -p sqd-hotblocks --bin sqd-hotblocks metrics::tests`
- `cargo test -p sqd-storage --release --lib measure_hash_index_compression_disk_size -- --ignored --nocapture`
- `cargo clippy -p sqd-storage -p sqd-hotblocks-harness -p sqd-hotblocks --all-targets`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
