### PR TITLE
refactor(hotblocks): consolidate head/finalized-head into one owner

### DIFF
--- a/crates/hotblocks/src/dataset_controller/dataset_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/dataset_controller.rs
@@ -1,19 +1,15 @@
-use std::{collections::BTreeMap, ops::Add, time::Duration};
+use std::{ops::Add, time::Duration};
 
 use anyhow::{Context, anyhow};
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
 use sqd_data_client::reqwest::ReqwestDataClient;
 use sqd_primitives::{BlockNumber, BlockRef};
-use sqd_storage::db::{Chunk, CompactionStatus, DatasetId};
+use sqd_storage::db::{CompactionStatus, DatasetId};
 use tokio::{select, task::JoinHandle, time::Instant};
 use tracing::{Instrument, debug, error, info, info_span, instrument, warn};
 
 use crate::{
-    dataset_controller::{
-        ingest::ingest,
-        ingest_generic::{IngestMessage, NewChunk},
-        write_controller::WriteController
-    },
+    dataset_controller::{ingest::ingest, ingest_generic::IngestMessage, write_controller::WriteController},
     types::{DBRef, DatasetKind, RetentionStrategy}
 };
 
@@ -45,19 +41,25 @@ impl DatasetController {
         retention: RetentionStrategy,
         data_sources: Vec<ReqwestDataClient>
     ) -> anyhow::Result<Self> {
-        let mut write = WriteController::new(db.clone(), dataset_id, dataset_kind)?;
+        let (head_sender, head_receiver) = tokio::sync::watch::channel(None);
+        let (finalized_head_sender, finalized_head_receiver) = tokio::sync::watch::channel(None);
+
+        // Channels live on the controller so they outlive writer restarts; each
+        // rebuilt writer gets a sender clone and seeds it from storage.
+        let mut write = WriteController::new(
+            db.clone(),
+            dataset_id,
+            dataset_kind,
+            head_sender.clone(),
+            finalized_head_sender.clone()
+        )?;
 
         if let RetentionStrategy::FromBlock { number, parent_hash } = &retention {
             write.init_retention(*number, parent_hash.clone())?;
         }
 
         let (retention_sender, retention_recv) = tokio::sync::watch::channel(retention);
-        let (head_sender, head_receiver) = tokio::sync::watch::channel(None);
-        let (finalized_head_sender, finalized_head_receiver) = tokio::sync::watch::channel(None);
         let (compaction_enabled_sender, compaction_enabled_receiver) = tokio::sync::watch::channel(false);
-
-        let _ = head_sender.send(write.head().cloned());
-        let _ = finalized_head_sender.send(write.finalized_head().cloned());
 
         let ctl = Ctl {
             db: db.clone(),
@@ -154,112 +156,6 @@ impl DatasetController {
     }
 }
 
-struct WriteCtx {
-    db: DBRef,
-    write: WriteController,
-    head_sender: tokio::sync::watch::Sender<Option<BlockRef>>,
-    finalized_head_sender: tokio::sync::watch::Sender<Option<BlockRef>>
-}
-
-impl WriteCtx {
-    fn handle_ingest_msg(&mut self, msg: IngestMessage, head: Option<u64>) -> anyhow::Result<()> {
-        match msg {
-            IngestMessage::FinalizedHead(head) => {
-                self.write.finalize(&head)?;
-                self.notify_finalized_head();
-            }
-            IngestMessage::NewChunk(new_chunk) => {
-                let ctx = format!("failed to write new chunk {}", new_chunk);
-                self.write_new_chunk(new_chunk).context(ctx)?;
-                self.notify_head();
-                self.notify_finalized_head();
-                if let Some(n) = head {
-                    if self
-                        .write
-                        .first_chunk_head()
-                        .map_or(false, |h| self.write.next_block() - h.number > n)
-                    {
-                        self.retain(self.write.next_block() - n, None)?;
-                    }
-                }
-            }
-            IngestMessage::Fork {
-                prev_blocks,
-                rollback_sender
-            } => {
-                self.write.compute_rollback(&prev_blocks).map(|rollback| {
-                    let _ = rollback_sender.send(rollback);
-                })?;
-            }
-        }
-        Ok(())
-    }
-
-    fn write_new_chunk(&mut self, mut new_chunk: NewChunk) -> anyhow::Result<()> {
-        let desc = self.write.dataset_kind().dataset_description();
-        let mut tables = BTreeMap::new();
-
-        for (name, prepared) in new_chunk.tables.iter_mut() {
-            let mut builder = self.db.new_table_builder(prepared.schema());
-
-            if let Some(table_desc) = desc.tables.get(name) {
-                for (&col, opts) in table_desc.options.column_options.iter() {
-                    if opts.stats_enable {
-                        builder.add_stat_by_name(col)?;
-                    }
-                }
-            }
-
-            prepared.read(&mut builder, 0, prepared.num_rows())?;
-
-            tables.insert(name.to_string(), builder.finish()?);
-        }
-
-        let chunk = Chunk::V1 {
-            parent_block_hash: new_chunk.parent_block_hash,
-            first_block: new_chunk.first_block,
-            last_block: new_chunk.last_block,
-            last_block_hash: new_chunk.last_block_hash,
-            first_block_time: new_chunk.first_block_time,
-            last_block_time: new_chunk.last_block_time,
-            tables
-        };
-
-        self.write.new_chunk(new_chunk.finalized_head.as_ref(), &chunk)
-    }
-
-    fn retain(&mut self, from_block: BlockNumber, parent_hash: Option<String>) -> anyhow::Result<()> {
-        self.write.retain(from_block, parent_hash)?;
-        self.notify_finalized_head();
-        self.notify_head();
-        Ok(())
-    }
-
-    fn notify_head(&self) {
-        send_if_new(&self.head_sender, self.write.head().cloned());
-    }
-
-    fn notify_finalized_head(&self) {
-        send_if_new(&self.finalized_head_sender, self.write.finalized_head().cloned())
-    }
-
-    fn starts_at(&self, block_number: BlockNumber, parent_hash: &Option<String>) -> bool {
-        self.write.start_block() == block_number
-            && self.write.start_block_parent_hash() == parent_hash.as_ref().map(String::as_str)
-    }
-}
-
-fn send_if_new<T: Eq>(sender: &tokio::sync::watch::Sender<T>, value: T) {
-    sender.send_if_modified(|current| {
-        if current == &value {
-            false
-        } else {
-            *current = value;
-            true
-        }
-    });
-}
-
 enum State {
     Idle,
     Init {
@@ -343,7 +239,7 @@ impl Ctl {
     }
 
     async fn write_epoch(&mut self, maybe_write: Option<WriteController>) -> anyhow::Result<()> {
-        let mut write = self.new_write_ctx(maybe_write).await?;
+        let mut write = self.new_write(maybe_write).await?;
 
         macro_rules! blocking {
             ($body:expr) => {
@@ -364,7 +260,7 @@ impl Ctl {
             }
             RetentionStrategy::Head(n) => State::Init { head: Some(n) },
             RetentionStrategy::None => {
-                if write.write.head().is_some() {
+                if write.head().is_some() {
                     State::Init { head: None }
                 } else {
                     State::Idle
@@ -399,9 +295,9 @@ impl Ctl {
                         },
                         top = future => {
                             let n = *head;
-                            let top = write.write.head().map_or(top, |h| h.number.max(top));
+                            let top = write.head().map_or(top, |h| h.number.max(top));
                             let first_block = top.saturating_sub(n);
-                            if first_block > write.write.start_block() {
+                            if first_block > write.start_block() {
                                 blocking! {
                                     write.retain(first_block, None)
                                 }?;
@@ -468,13 +364,17 @@ impl Ctl {
         }
     }
 
-    async fn handle_retention_change(&mut self, state: &mut State, mut write: WriteCtx) -> anyhow::Result<WriteCtx> {
+    async fn handle_retention_change(
+        &mut self,
+        state: &mut State,
+        mut write: WriteController
+    ) -> anyhow::Result<WriteController> {
         // need this variable to please the compiler
         let retention = self.retention_recv.borrow_and_update().clone();
         match retention {
             RetentionStrategy::FromBlock { number, parent_hash } => {
-                let will_erase_head = write.write.head().map_or(false, |h| h.number < number) || // FromBlock is greater than current head, so everything is cleared
-                    write.write.start_block() > number; // FromBlock is less than current front, dropping everything by design
+                let will_erase_head = write.head().map_or(false, |h| h.number < number) || // FromBlock is greater than current head, so everything is cleared
+                    write.start_block() > number; // FromBlock is less than current front, dropping everything by design
                 blocking_write!(write, write.retain(number, parent_hash))?;
                 match state {
                     State::Ingest { .. } if !will_erase_head => {} // Keep ingesting, head is valid
@@ -491,7 +391,7 @@ impl Ctl {
         Ok(write)
     }
 
-    fn spawn_ingest(&self, write: &WriteCtx) -> IngestHandle {
+    fn spawn_ingest(&self, write: &WriteController) -> IngestHandle {
         let (msg_sender, msg_recv) = tokio::sync::mpsc::channel(1);
 
         let ingest_span = info_span!("ingest");
@@ -501,8 +401,8 @@ impl Ctl {
                 msg_sender,
                 self.data_sources.clone(),
                 self.dataset_kind,
-                write.write.next_block(),
-                write.write.head_hash()
+                write.next_block(),
+                write.head_hash()
             )
             .instrument(ingest_span)
         );
@@ -510,29 +410,24 @@ impl Ctl {
         IngestHandle { msg_recv, task }
     }
 
-    async fn new_write_ctx(&self, maybe_write: Option<WriteController>) -> anyhow::Result<WriteCtx> {
+    async fn new_write(&self, maybe_write: Option<WriteController>) -> anyhow::Result<WriteController> {
+        if let Some(write) = maybe_write {
+            return Ok(write);
+        }
+
         let db = self.db.clone();
         let dataset_id = self.dataset_id;
         let dataset_kind = self.dataset_kind;
+        let head_sender = self.head_sender.clone();
+        let finalized_head_sender = self.finalized_head_sender.clone();
 
-        let write = if let Some(write) = maybe_write {
-            write
-        } else {
-            let span = tracing::Span::current();
-            tokio::task::spawn_blocking(move || {
-                let _entered = span.enter();
-                WriteController::new(db, dataset_id, dataset_kind)
-            })
-            .await
-            .context("write init task panicked")??
-        };
-
-        Ok(WriteCtx {
-            db: self.db.clone(),
-            write,
-            head_sender: self.head_sender.clone(),
-            finalized_head_sender: self.finalized_head_sender.clone()
+        let span = tracing::Span::current();
+        tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
+            WriteController::new(db, dataset_id, dataset_kind, head_sender, finalized_head_sender)
         })
+        .await
+        .context("write init task panicked")?
     }
 }
 

--- a/crates/hotblocks/src/dataset_controller/write_controller.rs
+++ b/crates/hotblocks/src/dataset_controller/write_controller.rs
@@ -1,9 +1,15 @@
-use anyhow::{anyhow, bail, ensure};
+use std::collections::BTreeMap;
+
+use anyhow::{Context, anyhow, bail, ensure};
 use sqd_primitives::{BlockNumber, BlockRef};
 use sqd_storage::db::{Chunk as StorageChunk, Chunk, DatasetId};
+use tokio::sync::watch;
 use tracing::{debug, field::valuable, info, instrument, warn};
 
-use crate::types::{DBRef, DatasetKind};
+use crate::{
+    dataset_controller::ingest_generic::{IngestMessage, NewChunk},
+    types::{DBRef, DatasetKind}
+};
 
 #[derive(Debug)]
 pub struct Rollback {
@@ -11,6 +17,10 @@ pub struct Rollback {
     pub parent_block_hash: Option<String>
 }
 
+/// Single writer for a dataset. Owns head/finalized-head as its working copy of
+/// committed state (WP-1) and publishes them through `set_head`/
+/// `set_finalized_head`, which update field and channel together only after the
+/// commit — so a published watermark is always already durable (INV-31/CN-4).
 #[derive(Debug)]
 pub struct WriteController {
     db: DBRef,
@@ -20,11 +30,19 @@ pub struct WriteController {
     parent_block_hash: Option<String>,
     first_chunk_head: Option<BlockRef>,
     head: Option<BlockRef>,
-    finalized_head: Option<BlockRef>
+    finalized_head: Option<BlockRef>,
+    head_sender: watch::Sender<Option<BlockRef>>,
+    finalized_head_sender: watch::Sender<Option<BlockRef>>
 }
 
 impl WriteController {
-    pub fn new(db: DBRef, dataset_id: DatasetId, dataset_kind: DatasetKind) -> anyhow::Result<Self> {
+    pub fn new(
+        db: DBRef,
+        dataset_id: DatasetId,
+        dataset_kind: DatasetKind,
+        head_sender: watch::Sender<Option<BlockRef>>,
+        finalized_head_sender: watch::Sender<Option<BlockRef>>
+    ) -> anyhow::Result<Self> {
         db.create_dataset_if_not_exists(dataset_id, dataset_kind.storage_kind())?;
 
         let snapshot = db.snapshot();
@@ -32,7 +50,7 @@ impl WriteController {
         let first_chunk = snapshot.get_first_chunk(dataset_id)?;
         let last_chunk = snapshot.get_last_chunk(dataset_id)?;
 
-        Ok(Self {
+        let this = Self {
             db: db.clone(),
             dataset_id,
             dataset_kind,
@@ -40,8 +58,16 @@ impl WriteController {
             parent_block_hash: first_chunk.as_ref().map(|c| c.last_block_hash().to_string()),
             first_chunk_head: first_chunk.as_ref().map(get_chunk_head),
             head: last_chunk.as_ref().map(get_chunk_head),
-            finalized_head: label.and_then(|l| l.finalized_head().cloned())
-        })
+            finalized_head: label.and_then(|l| l.finalized_head().cloned()),
+            head_sender,
+            finalized_head_sender
+        };
+
+        // Reseed subscribers to committed state (CN-9: recovery on writer rebuild).
+        this.publish_head();
+        this.publish_finalized_head();
+
+        Ok(this)
     }
 
     pub fn dataset_kind(&self) -> DatasetKind {
@@ -71,12 +97,28 @@ impl WriteController {
         self.head.as_ref()
     }
 
-    pub fn finalized_head(&self) -> Option<&BlockRef> {
-        self.finalized_head.as_ref()
-    }
-
     pub fn first_chunk_head(&self) -> Option<&BlockRef> {
         self.first_chunk_head.as_ref()
+    }
+
+    /// Publish only after the commit that produced `head`, never inside the txn
+    /// closure (INV-31: a published watermark must already be durable).
+    fn set_head(&mut self, head: Option<BlockRef>) {
+        self.head = head;
+        self.publish_head();
+    }
+
+    fn set_finalized_head(&mut self, finalized_head: Option<BlockRef>) {
+        self.finalized_head = finalized_head;
+        self.publish_finalized_head();
+    }
+
+    fn publish_head(&self) {
+        publish(&self.head_sender, self.head.clone());
+    }
+
+    fn publish_finalized_head(&self) {
+        publish(&self.finalized_head_sender, self.finalized_head.clone());
     }
 
     pub fn compute_rollback(&self, mut prev: &[BlockRef]) -> anyhow::Result<Rollback> {
@@ -234,8 +276,8 @@ impl WriteController {
                 head,
                 finalized_head
             } => {
-                self.head = Some(get_chunk_head(&head));
-                self.finalized_head = finalized_head;
+                self.set_head(Some(get_chunk_head(&head)));
+                self.set_finalized_head(finalized_head);
                 self.first_chunk_head = Some(get_chunk_head(&first_chunk));
                 info!(
                     "retained blocks from {} to {}",
@@ -266,8 +308,8 @@ impl WriteController {
     }
 
     fn clear_heads(&mut self) {
-        self.head = None;
-        self.finalized_head = None;
+        self.set_head(None);
+        self.set_finalized_head(None);
         self.first_chunk_head = None;
     }
 
@@ -329,7 +371,7 @@ impl WriteController {
                 block_hash = new_head.hash,
                 "saved new finalized head"
             );
-            self.finalized_head = Some(new_head);
+            self.set_finalized_head(Some(new_head));
         } else {
             debug!("finalized head was ignored")
         }
@@ -372,8 +414,9 @@ impl WriteController {
 
         debug!(finalized_head = valuable(&finalized_head), "saved new chunk");
 
-        self.finalized_head = finalized_head;
-        self.head = Some(get_chunk_head(&chunk));
+        // Head before finalized, so a subscriber never observes finalized > head (INV-5).
+        self.set_head(Some(get_chunk_head(&chunk)));
+        self.set_finalized_head(finalized_head);
         if self
             .first_chunk_head
             .as_ref()
@@ -384,11 +427,252 @@ impl WriteController {
 
         Ok(())
     }
+
+    /// `retain_from_head` is the `Head(n)` window size, if set; on EXTEND the
+    /// window is trimmed to keep at most `n` blocks behind the head.
+    pub fn handle_ingest_msg(&mut self, msg: IngestMessage, retain_from_head: Option<u64>) -> anyhow::Result<()> {
+        match msg {
+            IngestMessage::FinalizedHead(finalized_head) => {
+                self.finalize(&finalized_head)?;
+            }
+            IngestMessage::NewChunk(new_chunk) => {
+                let ctx = format!("failed to write new chunk {}", new_chunk);
+                self.write_new_chunk(new_chunk).context(ctx)?;
+                if let Some(n) = retain_from_head {
+                    if self
+                        .first_chunk_head()
+                        .map_or(false, |h| self.next_block() - h.number > n)
+                    {
+                        self.retain(self.next_block() - n, None)?;
+                    }
+                }
+            }
+            IngestMessage::Fork {
+                prev_blocks,
+                rollback_sender
+            } => {
+                self.compute_rollback(&prev_blocks).map(|rollback| {
+                    let _ = rollback_sender.send(rollback);
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn write_new_chunk(&mut self, mut new_chunk: NewChunk) -> anyhow::Result<()> {
+        let desc = self.dataset_kind().dataset_description();
+        let mut tables = BTreeMap::new();
+
+        for (name, prepared) in new_chunk.tables.iter_mut() {
+            let mut builder = self.db.new_table_builder(prepared.schema());
+
+            if let Some(table_desc) = desc.tables.get(name) {
+                for (&col, opts) in table_desc.options.column_options.iter() {
+                    if opts.stats_enable {
+                        builder.add_stat_by_name(col)?;
+                    }
+                }
+            }
+
+            prepared.read(&mut builder, 0, prepared.num_rows())?;
+
+            tables.insert(name.to_string(), builder.finish()?);
+        }
+
+        let chunk = Chunk::V1 {
+            parent_block_hash: new_chunk.parent_block_hash,
+            first_block: new_chunk.first_block,
+            last_block: new_chunk.last_block,
+            last_block_hash: new_chunk.last_block_hash,
+            first_block_time: new_chunk.first_block_time,
+            last_block_time: new_chunk.last_block_time,
+            tables
+        };
+
+        self.new_chunk(new_chunk.finalized_head.as_ref(), &chunk)
+    }
+
+    pub fn starts_at(&self, block_number: BlockNumber, parent_hash: &Option<String>) -> bool {
+        self.start_block() == block_number && self.start_block_parent_hash() == parent_hash.as_ref().map(String::as_str)
+    }
 }
 
 fn get_chunk_head(chunk: &Chunk) -> BlockRef {
     BlockRef {
         number: chunk.last_block(),
         hash: chunk.last_block_hash().to_string()
+    }
+}
+
+/// Publish only on a real change: a no-op FINALIZE must not wake
+/// `wait_for_finalized_block` waiters.
+fn publish(sender: &watch::Sender<Option<BlockRef>>, value: Option<BlockRef>) {
+    sender.send_if_modified(|current| {
+        if *current == value {
+            false
+        } else {
+            *current = value;
+            true
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use sqd_primitives::BlockRef;
+    use sqd_storage::db::{Chunk, DatabaseSettings, DatasetId};
+    use tokio::sync::watch;
+
+    use super::WriteController;
+    use crate::types::{DBRef, DatasetKind};
+
+    fn block(number: u64, hash: &str) -> BlockRef {
+        BlockRef {
+            number,
+            hash: hash.to_string()
+        }
+    }
+
+    /// Head/linkage metadata only — no Arrow tables (an empty table set skips
+    /// hash indexing; the head comes from `last_block`/`last_block_hash`).
+    fn chunk(first: u64, last: u64, last_hash: &str, parent_hash: &str) -> Chunk {
+        Chunk::V1 {
+            first_block: first,
+            last_block: last,
+            last_block_hash: last_hash.to_string(),
+            parent_block_hash: parent_hash.to_string(),
+            first_block_time: None,
+            last_block_time: None,
+            tables: BTreeMap::new()
+        }
+    }
+
+    struct Fixture {
+        db: DBRef,
+        dataset_id: DatasetId,
+        head_rx: watch::Receiver<Option<BlockRef>>,
+        fin_rx: watch::Receiver<Option<BlockRef>>,
+        wc: WriteController,
+        // Dropped last so RocksDB closes before the directory is removed.
+        _dir: tempfile::TempDir
+    }
+
+    fn fixture() -> Fixture {
+        let dir = tempfile::tempdir().unwrap();
+        let db: DBRef = Arc::new(DatabaseSettings::default().open(dir.path()).unwrap());
+        let dataset_id = DatasetId::from_str("evm-test");
+        let (head_tx, head_rx) = watch::channel(None);
+        let (fin_tx, fin_rx) = watch::channel(None);
+        let wc = WriteController::new(db.clone(), dataset_id, DatasetKind::Evm, head_tx, fin_tx).unwrap();
+        Fixture {
+            db,
+            dataset_id,
+            head_rx,
+            fin_rx,
+            wc,
+            _dir: dir
+        }
+    }
+
+    // INV-30/31: the published head equals what is durable in storage.
+    #[test]
+    fn new_chunk_publishes_committed_head() {
+        let mut f = fixture();
+        assert_eq!(*f.head_rx.borrow(), None);
+
+        f.wc.new_chunk(None, &chunk(1, 10, "h10", "h0")).unwrap();
+
+        assert_eq!(*f.head_rx.borrow(), Some(block(10, "h10")));
+        let stored = f.db.snapshot().get_last_chunk(f.dataset_id).unwrap().unwrap();
+        assert_eq!(stored.last_block(), 10);
+        assert_eq!(stored.last_block_hash(), "h10");
+    }
+
+    // INV-30: the published finalized head equals the storage label.
+    #[test]
+    fn finalize_publishes_committed_finalized_head() {
+        let mut f = fixture();
+        f.wc.new_chunk(None, &chunk(1, 10, "h10", "h0")).unwrap();
+        assert_eq!(*f.fin_rx.borrow(), None);
+
+        f.wc.finalize(&block(5, "h5")).unwrap();
+
+        assert_eq!(*f.fin_rx.borrow(), Some(block(5, "h5")));
+        let label = f.db.snapshot().get_label(f.dataset_id).unwrap().unwrap();
+        assert_eq!(label.finalized_head(), Some(&block(5, "h5")));
+    }
+
+    // INV-40/CN-9: a rebuilt writer reseeds subscribers from committed storage.
+    #[test]
+    fn rebuilt_writer_reseeds_watermarks_from_storage() {
+        let mut f = fixture();
+        f.wc.new_chunk(None, &chunk(1, 10, "h10", "h0")).unwrap();
+        f.wc.finalize(&block(5, "h5")).unwrap();
+        drop(f.wc);
+
+        let (head_tx, head_rx) = watch::channel(None);
+        let (fin_tx, fin_rx) = watch::channel(None);
+        let _wc = WriteController::new(f.db.clone(), f.dataset_id, DatasetKind::Evm, head_tx, fin_tx).unwrap();
+
+        assert_eq!(*head_rx.borrow(), Some(block(10, "h10")));
+        assert_eq!(*fin_rx.borrow(), Some(block(5, "h5")));
+    }
+
+    // Head-only progress must not fire the finalized channel — no spurious
+    // `wait_for_finalized_block` wakeups. Guards the `publish` dedup.
+    #[test]
+    fn head_only_progress_does_not_wake_finalized_waiters() {
+        let mut f = fixture();
+        f.wc.new_chunk(None, &chunk(1, 10, "h10", "h0")).unwrap();
+        // observe the current (still-None) finalized head
+        assert_eq!(*f.fin_rx.borrow_and_update(), None);
+
+        f.wc.new_chunk(None, &chunk(11, 20, "h20", "h10")).unwrap();
+
+        assert_eq!(*f.head_rx.borrow(), Some(block(20, "h20")));
+        assert!(
+            !f.fin_rx.has_changed().unwrap(),
+            "finalized head must stay unchanged while unfinalized blocks arrive"
+        );
+    }
+
+    // Perf probe over the real read (`get_head` == borrow+clone) and write
+    // (commit→set_head→publish) paths. Run:
+    //   cargo test -p sqd-hotblocks --bin sqd-hotblocks -- --ignored --nocapture watermark_hotpath
+    #[test]
+    #[ignore]
+    fn watermark_hotpath_throughput() {
+        use std::time::Instant;
+
+        let mut f = fixture();
+        f.wc.new_chunk(None, &chunk(1, 10, "h10", "h0")).unwrap();
+
+        let reads = 2_000_000u32;
+        let t = Instant::now();
+        let mut last = None;
+        for _ in 0..reads {
+            last = f.head_rx.borrow().clone();
+        }
+        let read_ns = t.elapsed().as_nanos() as f64 / reads as f64;
+        assert_eq!(last, Some(block(10, "h10")));
+        eprintln!("watermark read: {read_ns:.1} ns/op");
+
+        let commits = 5_000u64;
+        let mut parent = "h10".to_string();
+        let mut last_block = 10u64;
+        let t = Instant::now();
+        for _ in 0..commits {
+            let first = last_block + 1;
+            let last = last_block + 10;
+            let hash = format!("h{last}");
+            f.wc.new_chunk(None, &chunk(first, last, &hash, &parent)).unwrap();
+            parent = hash;
+            last_block = last;
+        }
+        let commit_us = t.elapsed().as_micros() as f64 / commits as f64;
+        eprintln!("chunk commit + publish: {commit_us:.1} us/op");
+        assert_eq!(*f.head_rx.borrow(), Some(block(last_block, &parent)));
     }
 }


### PR DESCRIPTION
## What

Head and finalized-head were tracked in **two in-memory places** kept in sync by hand:

- `WriteController` fields (`head`, `finalized_head`) — the writer's working copy;
- `DatasetController` watch channels — the async readers' copy,

wired together by a `WriteCtx` wrapper whose `notify_head` / `notify_finalized_head` had to be called after every write. A write that mutated state but forgot to notify would silently stall `wait_for_block`, and the wrapper leaked into the control loop as the `write.write.` double-indirection.

This PR makes the **writer the single owner**: `WriteController` holds the watch senders and every watermark mutation goes through `set_head` / `set_finalized_head`, which update the field *and* publish in one place. `WriteCtx` is dissolved into `WriteController`.

```
before                                   after
------                                   -----
RocksDB label + last chunk  (durable)    RocksDB label + last chunk  (durable, unchanged)
WriteController fields      (writer)     WriteController fields       (writer's committed mirror)
DatasetController channels  (readers) →  …owned by the writer, published via setters
WriteCtx.notify_* (manual sync)          (gone)
```

No new RocksDB reads, no new locks on any hot path — the watch read stays an in-memory borrow and publishing stays one `send_if_modified` per commit.

## Why it's correct (spec-grounded)

The spec (`crates/hotblocks/spec/`) is a **black-box** contract (IB-8/IB-9), so this internal restructuring is legal as long as the observable invariants hold. The two that govern it:

- **INV-31 / CN-4 — real-time monotonic reads** ("a reported head is immediately queryable"). The setters run *after* `update_dataset(...)` commits, so a published watermark is always already durable — the channel never leads storage. The plain `head` field is deliberately **kept** as the writer's committed-state mirror (**WP-1**: continuation derives from committed state, never a transient in-memory value); reading it back from the channel would pin a watch read-lock across the RocksDB transaction inside `finalize()`.
- **INV-40 / CN-9 — recovery reconstructs cached values exactly.** Seeding moves into `WriteController::new`, and the senders live on the controller (cloned into each rebuilt writer), so **restart re-seed is now automatic** instead of a one-shot seed in `DatasetController::new`.

Deliberately **not** merged (looks redundant, isn't): the durable label; `head` derived from the last chunk (not a stored field); and the query path's `finalized_head` read from its own `StaticSnapshot` (`running.rs`) — using the async cache there would be a TOCTOU bug.

## Tests

New `WriteController` unit tests close the two properties the conformance matrix (`12-conformance-tdd.md`) flags as **untested**:

| Test | Property |
|---|---|
| `new_chunk_publishes_committed_head` | published head == durable storage (INV-30/31) |
| `finalize_publishes_committed_finalized_head` | published finalized head == label (INV-6/30) |
| `rebuilt_writer_reseeds_watermarks_from_storage` | restart re-seed (INV-40/CN-9) |
| `head_only_progress_does_not_wake_finalized_waiters` | no spurious finalized wakeups (dedup) |

Plus an `#[ignore]` perf probe over the real refactored paths:

```
watermark read:          136.2 ns/op   (borrow + clone, no I/O)
chunk commit + publish:  49.4  us/op   (dominated by the RocksDB txn, not publish)
```

`cargo test -p sqd-hotblocks` — green: unit (8 pass / 2 ignored), `block_hash_index` (2), `ct1_happy_path` (3), `ct9_source_faults` (1). The CT integration tests drive the real binary black-box, so their passing confirms the external contract is unchanged.

## Note — pre-existing, not touched

`WriteController::new` seeds the anchor as `first_chunk.last_block_hash()` where the anchor hash is `first_chunk.parent_block_hash()` (spec **GAP-2**, P1). Preserved verbatim here to keep this a pure no-behavior-change refactor; flagged for its own fix + CT-2 test.
