### PR TITLE
feat(hotblocks): name the serving instance on every response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
  "futures",
  "ouroboros",
  "prometheus-client 0.24.0",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/hotblocks/Cargo.toml
+++ b/crates/hotblocks/Cargo.toml
@@ -36,6 +36,7 @@ url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+reqwest = { workspace = true }
 sqd-hotblocks-harness = { path = "../hotblocks-harness" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/hotblocks/src/api.rs
+++ b/crates/hotblocks/src/api.rs
@@ -1,4 +1,8 @@
-use std::{future::Future, sync::Arc, time::Instant};
+use std::{
+    future::Future,
+    sync::{Arc, LazyLock},
+    time::Instant
+};
 
 use anyhow::bail;
 use async_stream::try_stream;
@@ -6,7 +10,7 @@ use axum::{
     BoxError, Extension, Json, Router,
     body::{Body, Bytes},
     extract::{Path, Request},
-    http::{HeaderMap, StatusCode, Uri},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri},
     response::{IntoResponse, Response},
     routing::{get, post}
 };
@@ -131,6 +135,40 @@ mod hash_validation_tests {
     }
 }
 
+/// Names the replica that served a response. A Service load-balances across replicas behind
+/// one ClusterIP, so a caller cannot otherwise tell them apart. The portal logs this and
+/// strips every `x-internal-*` header before responding, so it never reaches a client.
+const INSTANCE_HEADER: HeaderName = HeaderName::from_static("x-internal-hotblocks-instance");
+
+/// An empty or unrepresentable name resolves to `unknown`, never to an empty value: the
+/// portal reads this as a name or as `unknown`, and must never have to treat "" as either.
+fn instance_header(hostname: Option<&str>) -> HeaderValue {
+    hostname
+        .filter(|name| !name.is_empty())
+        .and_then(|name| HeaderValue::from_str(name).ok())
+        .unwrap_or_else(|| HeaderValue::from_static("unknown"))
+}
+
+/// Kubernetes sets HOSTNAME to the pod name.
+static INSTANCE: LazyLock<HeaderValue> = LazyLock::new(|| instance_header(std::env::var("HOSTNAME").ok().as_deref()));
+
+#[cfg(test)]
+mod instance_header_tests {
+    use super::*;
+
+    #[test]
+    fn hostname_names_the_instance() {
+        assert_eq!(instance_header(Some("hotblocks-db-0")), "hotblocks-db-0");
+    }
+
+    #[test]
+    fn absent_empty_and_unrepresentable_all_collapse_to_unknown() {
+        assert_eq!(instance_header(None), "unknown");
+        assert_eq!(instance_header(Some("")), "unknown");
+        assert_eq!(instance_header(Some("pod\nname")), "unknown");
+    }
+}
+
 pub async fn middleware(mut req: Request, next: axum::middleware::Next) -> impl IntoResponse {
     let method = req.method().to_string();
     let path = req.uri().path().to_string();
@@ -160,6 +198,8 @@ pub async fn middleware(mut req: Request, next: axum::middleware::Next) -> impl 
     let span = tracing::span!(tracing::Level::INFO, "http_request", request_id);
     let mut response = next.run(req).instrument(span.clone()).await;
     let latency = start.elapsed();
+
+    response.headers_mut().insert(INSTANCE_HEADER, INSTANCE.clone());
 
     let mut labels = response
         .extensions_mut()

--- a/crates/hotblocks/tests/instance_header.rs
+++ b/crates/hotblocks/tests/instance_header.rs
@@ -1,0 +1,37 @@
+//! The instance header is a cross-repo contract: the portal reads it to attribute a response
+//! to a replica, and strips every `x-internal-*` header before answering a client. Nothing on
+//! the portal side can tell that hotblocks stopped sending it — the field just reads "-".
+
+use std::time::Duration;
+
+use anyhow::Result;
+use sqd_hotblocks_harness::sut::{Sut, SutConfig};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn every_response_names_the_serving_instance() -> Result<()> {
+    let sut = Sut::start(SutConfig {
+        bin: env!("CARGO_BIN_EXE_sqd-hotblocks").into(),
+        datasets: vec![],
+        args: vec![],
+        rust_log: "error".to_owned(),
+        startup_timeout: Duration::from_secs(30)
+    })
+    .await?;
+
+    // `/` needs no dataset: the header comes from the middleware, so any route proves it.
+    let response = reqwest::get(sut.base_url()).await?;
+
+    let instance = response
+        .headers()
+        .get("x-internal-hotblocks-instance")
+        .expect("every response must name its instance");
+
+    // HOSTNAME is the pod name under Kubernetes; a dev machine may not set it at all, and the
+    // fallback is what keeps the header present rather than absent.
+    assert!(
+        !instance.is_empty(),
+        "the instance header must never be empty: the portal cannot distinguish it from absent"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Why

`hotblocks-db` is a StatefulSet behind a **ClusterIP** Service. The portal connects to the Service's virtual IP and kube-proxy DNATs to a pod in the kernel, so `getpeername()` — and therefore anything reqwest can report — returns the ClusterIP. **The portal cannot tell which replica answered.**

This adds `x-internal-hotblocks-instance: <pod>` to every response, so it can.

## Merging is safe. Deploying is gated.

sqd-portal strips every `x-internal-*` header before responding (subsquid/sqd-portal#133, released in 0.11.8) and logs this one on a 5xx. But that strip is **released, not deployed**, and the deploy is what matters:

Only 0.11.8 carries the strip (`git tag --contains 9d08fba` → `v0.11.8` alone); below it `forward_response` copies every upstream header verbatim, with no filter at all. **Every hotblocks namespace is fronted by at least one portal that does not strip**, and `portal.sqd.dev` is one of them.

## Implementation

One line in the existing `middleware`, which wraps every route — `.fallback()` is applied before `.layer()`, and `axum::serve` puts nothing outside it, so 404s are covered too. No new layer, no tower-http feature.

`HOSTNAME` is read once via `LazyLock` (Kubernetes sets it to the pod name). Resolution lives in a pure `instance_header()` so the mapping is testable without racing on process-global env. Absent, empty, and unrepresentable names all collapse to `unknown`: the header is always present and never empty, so the portal never has to distinguish "absent" from "unset" — and an empty value would have reintroduced exactly that ambiguity.

## Test

`tests/instance_header.rs` drives the **real binary** through the harness and asserts the header is present. Verified it catches the regression — with the insert removed it fails with `every response must name its instance`.

That test can't pin the `HOSTNAME` → header mapping: the harness inherits the parent env, and `HOSTNAME` is unexported on dev machines and on bare CI runners, so it only ever exercises the fallback. `instance_header_tests` pins the mapping directly instead — deleting the empty-guard fails them with `left: "" / right: "unknown"`.

## Scope — worth being clear

This names the replica **only for requests that got a response**. It does not help the case that motivated it: a request that stalls before headers has no response to carry any header, and that is exactly the `/head` timeout a tenant hit on 2026-07-16. For a wedged replica, hotblocks' own per-pod metrics remain the only signal. This earns its place for 5xx attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
