### PR TITLE
fix(hotblocks-retain): act on SIGTERM instead of waiting for the kill

### DIFF
--- a/crates/hotblocks-retain/src/main.rs
+++ b/crates/hotblocks-retain/src/main.rs
@@ -12,7 +12,10 @@ use std::{
 use anyhow::Context;
 use clap::Parser;
 use cli::Cli;
-use tokio::time::Instant;
+use tokio::{
+    signal::unix::{SignalKind, signal},
+    time::Instant
+};
 use types::{DatasetId, DatasetsConfig};
 use url::Url;
 
@@ -31,17 +34,29 @@ fn main() -> anyhow::Result<()> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?
-        .block_on(
-            HotblocksRetain::new(
+        .block_on(async {
+            let mut retain = HotblocksRetain::new(
                 args.hotblocks_url,
                 args.status_url,
                 args.datasets_url,
                 datasets,
                 Duration::from_secs(args.datasets_update_interval_secs),
                 Duration::from_secs(args.retain_delay_secs)
-            )
-            .run()
-        )?;
+            );
+
+            // We run as PID 1, which Linux gives no default signal dispositions: without a
+            // handler installed SIGTERM is ignored outright, not fatal. SIGINT is left alone
+            // so a dev Ctrl-C keeps working.
+            let mut sigterm = signal(SignalKind::terminate()).context("failed to install the SIGTERM handler")?;
+
+            tokio::select! {
+                res = retain.run() => res,
+                _ = sigterm.recv() => {
+                    tracing::info!("SIGTERM received, exiting");
+                    Ok(())
+                }
+            }
+        })?;
 
     Ok(())
 }


### PR DESCRIPTION
`sqd-hotblocks-retain` has no signal handling, and it runs as **PID 1** in its container. Linux gives PID 1 no default signal dispositions: a signal with no handler installed is *ignored*, not fatal. SIGTERM therefore did nothing, and since the loop sleeps up to an hour between passes, SIGKILL at the end of the shutdown grace was the only thing that ever stopped this process.

That shows up as the container outliving its neighbours by the whole grace window and dying by signal, while the rest of the pod exits cleanly — pure dead time on every restart, and it grows with whatever grace the deployment needs.

### The fix

Race the loop against a SIGTERM handler. Exiting immediately is safe here: retention is applied over HTTP and nothing is held locally, so a pass cut mid-flight is recomputed from the scheduler status on the next start.

SIGINT stays on the default handler, matching the hotblocks binary — a dev Ctrl-C is not PID 1, so it already works.

### Verification

Ran the built binary against dead upstreams and signalled it: exits 0 having logged `SIGTERM received, exiting`, where an uninstalled handler would give 143 and no log line. The signal is caught mid-sleep, so the select races the timer correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)