### PR TITLE
feat(hotblocks): expose the LSM base level size

### DIFF
--- a/crates/hotblocks/src/cli.rs
+++ b/crates/hotblocks/src/cli.rs
@@ -91,6 +91,15 @@ pub struct CLI {
     #[arg(long, value_name = "N", default_value = "2")]
     pub rocksdb_max_write_buffers: i32,
 
+    /// Target size of the LSM base level. With ~60 GB live and the default
+    /// multiplier of 10, this decides how many levels deep the ladder runs, and
+    /// a byte is rewritten once per level it descends. The default 256 MB is
+    /// smaller than one 512 MB memtable's flush, so L0 currently arrives larger
+    /// than the level it merges into. Unmeasured at production scale -- see
+    /// docs/measurements/2026-07-27-rocksdb-memtable-tuning.md before setting it.
+    #[arg(long, value_name = "MB", default_value = "256")]
+    pub rocksdb_level_base_mb: usize,
+
     /// Rewrite every table SST older than this, collecting dead data that never made a file
     /// tombstone-dense enough for the deletion collector. Lower means faster reclaim and
     /// proportionally more write amplification. 0 disables it, leaving RocksDB's 30-day
@@ -165,6 +174,7 @@ impl CLI {
             .with_periodic_compaction_secs(self.rocksdb_periodic_compaction_secs)
             .with_write_buffer_mb(self.rocksdb_write_buffer_mb)
             .with_max_write_buffers(self.rocksdb_max_write_buffers)
+            .with_level_base_mb(self.rocksdb_level_base_mb)
             .with_block_hash_index(self.block_hash_index)
             .with_transaction_hash_index(self.transaction_hash_index);
 

--- a/crates/storage/src/db/db.rs
+++ b/crates/storage/src/db/db.rs
@@ -60,6 +60,7 @@ pub struct DatabaseSettings {
     with_rocksdb_stats: bool,
     write_buffer_mb: usize,
     max_write_buffers: i32,
+    level_base_mb: usize,
     direct_io: bool,
     cache_index_and_filter_blocks: bool,
     max_log_file_size: usize,
@@ -89,6 +90,7 @@ impl Default for DatabaseSettings {
             // RocksDB's own defaults; the CLI carries the deployed values
             write_buffer_mb: 64,
             max_write_buffers: 2,
+            level_base_mb: 256,
             direct_io: false,
             cache_index_and_filter_blocks: false,
             max_log_file_size: 10,
@@ -130,6 +132,11 @@ impl DatabaseSettings {
 
     pub fn with_max_write_buffers(mut self, n: i32) -> Self {
         self.max_write_buffers = n;
+        self
+    }
+
+    pub fn with_level_base_mb(mut self, mb: usize) -> Self {
+        self.level_base_mb = mb;
         self
     }
 
@@ -257,6 +264,10 @@ impl DatabaseSettings {
         // memory cost (write_buffer_mb x max_write_buffers) is paid once rather than per CF.
         options.set_write_buffer_size(self.write_buffer_mb << 20);
         options.set_max_write_buffer_number(self.max_write_buffers);
+        // Sets how many levels the ladder has, and a byte is rewritten once per level.
+        // Wants to be >= level0_file_num_compaction_trigger x the compressed flush size,
+        // or L0 arrives larger than the level it merges into.
+        options.set_max_bytes_for_level_base((self.level_base_mb as u64) << 20);
         if !self.auto_compactions {
             options.set_disable_auto_compactions(true);
         }


### PR DESCRIPTION
Adds `--rocksdb-level-base-mb`. Default stays RocksDB's own 256 MB, so this is inert until a deployment sets it — same pattern as the memtable flags in #106.

## Why now

Two independent reasons, both surfaced by the production roll of #106.

**1. The memtable change left the ladder mis-sized.** Raising `write_buffer_size` 64 → 512 MB without touching the base inverted the L0/L1 relationship:

| | before | after #106 |
|---|---|---|
| compressed L0 file per flush | ~16 MB | ~128 MB |
| 4 files = compaction trigger | 64 MB | **512 MB** |
| target L1 (`max_bytes_for_level_base`) | 256 MB | 256 MB |
| L1 / L0 | 4 — healthy | **0.5 — inverted** |

L0 now arrives larger than the level it merges into, so every L0 compaction rewrites all of L1 and immediately pushes it down. Canonical pairing is base ≥ `level0_file_num_compaction_trigger` × compressed flush size.

**2. It is the lever the memtable could not reach.** A byte is rewritten once per level it descends. Memtable size only addresses the L0→L1 hop; at ~60 GB live the ladder runs several levels deeper and that work is untouched by it.

Production bears this out. The bench predicted 2.4× fewer device writes — measured at ~130 MB live, where there is barely a ladder. What internal actually delivered at ~60 GB live, 35 min post-roll:

| | before | after | |
|---|---|---|---|
| device writes | 307 / 322 MiB/s | 184 / 193 | **−40 % (1.67×)** |
| CPU | 2.52 / 2.62 cores | 1.84 / 2.07 | −27 % |

morpho, which writes least and is therefore WAL-dominated, got only −23 % — consistent with the same model from the other end.

The write-stall fix from #106 is unambiguous and unaffected by any of this: `write_stopped` 1.206 % → 0 on internal-db-1, `immutable_memtables` 1 of 4 across all eight pods, zero restarts on the roll.

## What this PR deliberately does not do

**It does not set a value, and the value is unmeasured.** The bench cannot price this parameter: at 130 MB live there is no ladder to shorten, so a sweep there would measure noise. Pricing it needs a bench run with live size in the GBs — materially longer than the runs behind #106 — or a canary on internal.

Suggested starting point when someone does measure it: 2 GB and 4 GB against the current 256 MB, all at `512 × 4` + direct I/O.

## Cost of raising it

Fewer levels ⇒ lower write amplification, but larger individual compactions, more transient space during them, and read amplification roughly flat or slightly better. Nothing here is free at 60 GB live, which is exactly why the default is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)